### PR TITLE
feat: robust file persistence with atomic saves and auto-save ticker

### DIFF
--- a/cmd/miniblue/main.go
+++ b/cmd/miniblue/main.go
@@ -42,6 +42,7 @@ Environment variables:
   LOG_LEVEL              Log level: debug, info, warn, error (default: info)
   DATABASE_URL           PostgreSQL URL for persistent storage
   PERSISTENCE            Set to 1 to enable file-based state persistence (~/.miniblue/state.json)
+  MINIBLUE_SAVE_INTERVAL Auto-save interval for file persistence (default: 30s, e.g. 10s, 1m)
   SERVICES               Comma-separated list of services to enable (default: all)
   POSTGRES_URL           Real PostgreSQL for DB for PostgreSQL service
   REDIS_URL              Real Redis for Azure Cache for Redis service
@@ -122,11 +123,30 @@ Documentation: https://moabukar.github.io/miniblue`)
 	// Run init hooks
 	go runInitHooks()
 
+	// Start periodic auto-save for file persistence
+	var stopAutoSave func()
+	if os.Getenv("PERSISTENCE") == "1" {
+		interval := 30 * time.Second
+		if v := os.Getenv("MINIBLUE_SAVE_INTERVAL"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil {
+				interval = d
+			} else {
+				log.Printf("invalid MINIBLUE_SAVE_INTERVAL %q, using default 30s", v)
+			}
+		}
+		stopAutoSave = srv.StartAutoSave(interval)
+	}
+
 	// Block until shutdown signal
 	<-stop
 	log.Println("miniblue shutting down gracefully...")
 
-	// Save state on shutdown if using file persistence
+	// Stop auto-save ticker
+	if stopAutoSave != nil {
+		stopAutoSave()
+	}
+
+	// Final save on shutdown if using file persistence
 	if os.Getenv("PERSISTENCE") == "1" {
 		log.Println("saving state to disk...")
 		if err := srv.SaveState(); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -61,6 +61,12 @@ func (s *Server) SaveState() error {
 	return s.store.Save()
 }
 
+// StartAutoSave starts periodic background saves for file-based persistence.
+// Returns a stop function that must be called on shutdown.
+func (s *Server) StartAutoSave(interval time.Duration) func() {
+	return s.store.StartAutoSave(interval)
+}
+
 func (s *Server) setupMiddleware() {
 	s.router.Use(CORS)
 	s.router.Use(StructuredLogger)

--- a/internal/store/file.go
+++ b/internal/store/file.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 type FileBackend struct {
@@ -41,6 +42,8 @@ func (f *FileBackend) load() {
 	log.Printf("loaded %d items from %s", len(state), f.path)
 }
 
+// Save atomically persists all in-memory state to disk.
+// It writes to a .tmp file first and then renames it to avoid corruption on crash.
 func (f *FileBackend) Save() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -57,8 +60,39 @@ func (f *FileBackend) Save() error {
 		return err
 	}
 	dir := filepath.Dir(f.path)
-	os.MkdirAll(dir, 0700)
-	return os.WriteFile(f.path, data, 0644)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	// Write to a temp file first, then atomically rename to avoid corruption.
+	tmp := f.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, f.path)
+}
+
+// StartAutoSave starts a background goroutine that saves state to disk every
+// interval. Call the returned stop function to halt it (e.g. on shutdown).
+// The stop function is safe to call multiple times.
+func (f *FileBackend) StartAutoSave(interval time.Duration) func() {
+	ticker := time.NewTicker(interval)
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				if err := f.Save(); err != nil {
+					log.Printf("auto-save failed: %v", err)
+				}
+			case <-done:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+	log.Printf("auto-save enabled: saving every %s to %s", interval, f.path)
+	return func() { once.Do(func() { close(done) }) }
 }
 
 // Delegate all Backend methods to the in-memory backend
@@ -66,8 +100,10 @@ func (f *FileBackend) Set(key string, value interface{}) error { return f.mem.Se
 func (f *FileBackend) Get(key string) (interface{}, bool)      { return f.mem.Get(key) }
 func (f *FileBackend) Delete(key string) bool                  { return f.mem.Delete(key) }
 func (f *FileBackend) List() []string                          { return f.mem.List() }
-func (f *FileBackend) ListByPrefix(prefix string) []interface{} { return f.mem.ListByPrefix(prefix) }
-func (f *FileBackend) CountByPrefix(prefix string) int         { return f.mem.CountByPrefix(prefix) }
-func (f *FileBackend) Exists(key string) bool                  { return f.mem.Exists(key) }
-func (f *FileBackend) DeleteByPrefix(prefix string) int        { return f.mem.DeleteByPrefix(prefix) }
-func (f *FileBackend) Reset()                                  { f.mem.Reset() }
+func (f *FileBackend) ListByPrefix(prefix string) []interface{} {
+	return f.mem.ListByPrefix(prefix)
+}
+func (f *FileBackend) CountByPrefix(prefix string) int  { return f.mem.CountByPrefix(prefix) }
+func (f *FileBackend) Exists(key string) bool           { return f.mem.Exists(key) }
+func (f *FileBackend) DeleteByPrefix(prefix string) int { return f.mem.DeleteByPrefix(prefix) }
+func (f *FileBackend) Reset()                           { f.mem.Reset() }

--- a/internal/store/file_test.go
+++ b/internal/store/file_test.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileBackend_AtomicSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	fb := NewFileBackend(path)
+	fb.Set("key1", "value1")
+	fb.Set("key2", 42.0)
+
+	if err := fb.Save(); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Temp file must not exist after successful save
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error("temp file still exists after Save()")
+	}
+
+	// State file must exist and contain correct data
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var state map[string]interface{}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if state["key1"] != "value1" {
+		t.Errorf("key1: got %v, want value1", state["key1"])
+	}
+	if state["key2"] != 42.0 {
+		t.Errorf("key2: got %v, want 42", state["key2"])
+	}
+}
+
+func TestFileBackend_LoadExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// Write initial state
+	fb := NewFileBackend(path)
+	fb.Set("persistent", "yes")
+	if err := fb.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Load a new backend from the same path
+	fb2 := NewFileBackend(path)
+	v, ok := fb2.Get("persistent")
+	if !ok {
+		t.Fatal("key 'persistent' not found after reload")
+	}
+	if v != "yes" {
+		t.Errorf("got %v, want yes", v)
+	}
+}
+
+func TestFileBackend_AutoSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	fb := NewFileBackend(path)
+	stop := fb.StartAutoSave(50 * time.Millisecond)
+	defer stop()
+
+	fb.Set("auto", "saved")
+
+	// Wait for at least one auto-save tick
+	time.Sleep(150 * time.Millisecond)
+
+	// File must exist now
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("auto-save did not create state file")
+	}
+
+	stop()
+
+	// Reload and verify
+	fb2 := NewFileBackend(path)
+	v, ok := fb2.Get("auto")
+	if !ok {
+		t.Fatal("key 'auto' not found after auto-save")
+	}
+	if v != "saved" {
+		t.Errorf("got %v, want saved", v)
+	}
+}
+
+func TestStore_StartAutoSave_NoOp_MemoryBackend(t *testing.T) {
+	s := New() // memory backend
+	stop := s.StartAutoSave(10 * time.Millisecond)
+	// Should not panic and stop should be callable
+	time.Sleep(20 * time.Millisecond)
+	stop()
+}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -3,6 +3,7 @@ package store
 import (
 	"strings"
 	"sync"
+	"time"
 )
 
 // MemoryBackend is an in-memory implementation of the Backend interface.
@@ -189,4 +190,13 @@ func (s *Store) Save() error {
 		return fb.Save()
 	}
 	return nil
+}
+
+// StartAutoSave starts periodic auto-save if the backend is a FileBackend.
+// Returns a no-op stop function for other backends.
+func (s *Store) StartAutoSave(interval time.Duration) func() {
+	if fb, ok := s.backend.(*FileBackend); ok {
+		return fb.StartAutoSave(interval)
+	}
+	return func() {}
 }


### PR DESCRIPTION
## Summary

- `Save()` now uses atomic writes (write to `.tmp` then `rename`) - state file can no longer be corrupted by a crash or power loss mid-write
- New `StartAutoSave(interval)` on `FileBackend` - background ticker saves every N seconds (default 30s), not just on clean shutdown
- `MINIBLUE_SAVE_INTERVAL` env var to configure the interval (e.g. `10s`, `1m`)
- Stop function uses `sync.Once` so it's safe to call multiple times
- Exposed cleanly through `Store` and `Server` layers - `main.go` starts/stops it around the server lifecycle
- 4 new tests in `internal/store/file_test.go` covering atomic save, reload from disk, auto-save ticker, and no-op on memory backend

## Usage

```bash
# Enable file persistence with default 30s auto-save
PERSISTENCE=1 miniblue

# Custom interval
PERSISTENCE=1 MINIBLUE_SAVE_INTERVAL=10s miniblue
```

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass (store tests + integration tests)
- [x] `TestFileBackend_AtomicSave` - verifies no `.tmp` file left, correct JSON written
- [x] `TestFileBackend_LoadExisting` - verifies state survives restart
- [x] `TestFileBackend_AutoSave` - verifies file written within ticker interval
- [x] `TestStore_StartAutoSave_NoOp_MemoryBackend` - no panic on non-file backend