### PR TITLE
feat: add Pulumi Python example + README fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,20 @@ Thanks for your interest in contributing! Here is how you can help.
 6. Commit and push
 7. Open a Pull Request
 
+## Prerequisites for Python Examples
+
+On Debian/Ubuntu you need `python3-venv` (or the version-specific variant) before creating a virtualenv:
+
+```bash
+# Debian/Ubuntu
+sudo apt install python3.12-venv   # or python3-venv for the system default
+
+# Then create a venv as normal
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
 ## Adding a New Azure Service
 
 Each service lives in its own package under `internal/services/`. Follow the existing pattern:

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ The Azure ecosystem today forces developers to cobble together individual emulat
 
 That is 5 separate tools, 5 different Docker images, 5 different ports and configs - just to get basic local dev working. And you still have no local emulation for Resource Groups, Key Vault, DNS, VNets, Event Grid, ACR, or Managed Identity.
 
-**miniblue gives you 19 Azure services on a single port.** One binary, one Docker image, zero config.
+**miniblue gives you 21 Azure services on a single port.** One binary, one Docker image, zero config.
 
 ### How it compares
 
 | | LocalStack (AWS) | MiniStack (AWS) | Azurite (Azure) | miniblue |
 |---|---|---|---|---|
-| Services | 80+ | 36 | 3 (storage only) | **19** |
+| Services | 80+ | 36 | 3 (storage only) | **21** |
 | Single port | 4566 | 4566 | 10000-10002 | 4566 |
 | Language | Python | Python | Node.js | **Go** |
 | Auth required | No (free tier) | No | No | No |
@@ -67,7 +67,7 @@ miniblue fills this gap for Azure developers.
 
 ## What miniblue is
 
-- **19 Azure services** emulated behind a single port (4566)
+- **21 Azure services** emulated behind a single port (4566)
 - **Drop-in compatible** with Azure SDKs, Terraform, Pulumi
 - **In-memory storage** by default (fast, ephemeral)
 - **Docker-first** deployment
@@ -306,7 +306,7 @@ Adding a new service is straightforward - each service is its own Go package und
 - [ ] More services (Redis Cache, App Service, AKS, etc.)
 - [ ] Terraform provider integration tests
 - [ ] Web UI for visualising resources
-- [ ] Pulumi integration
+- [x] Pulumi integration (see `examples/pulumi-python/`)
 
 ## License
 

--- a/examples/pulumi-python/.gitignore
+++ b/examples/pulumi-python/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+*.pyc
+.pulumi/

--- a/examples/pulumi-python/Pulumi.dev.yaml
+++ b/examples/pulumi-python/Pulumi.dev.yaml
@@ -1,0 +1,1 @@
+encryptionsalt: v1:9xo/GfOGHhg=:v1:VlrctHDjFcqyPu6I:FT48AWCiyTqqfVW7GViyOnDK93m3AQ==

--- a/examples/pulumi-python/Pulumi.yaml
+++ b/examples/pulumi-python/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: miniblue-pulumi-python
+runtime: python
+description: Pulumi Python example for miniblue (local Azure emulator)

--- a/examples/pulumi-python/README.md
+++ b/examples/pulumi-python/README.md
@@ -1,0 +1,14 @@
+# miniblue Pulumi Python example
+
+Start miniblue first: `./bin/miniblue`
+
+```bash
+cd examples/pulumi-python
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+pulumi login --local
+pulumi stack init dev
+pulumi up --yes --skip-preview
+pulumi destroy --yes --skip-preview
+```

--- a/examples/pulumi-python/__main__.py
+++ b/examples/pulumi-python/__main__.py
@@ -1,0 +1,231 @@
+"""
+miniblue Pulumi Python example using dynamic providers.
+
+Uses Pulumi dynamic providers to make HTTP calls directly to miniblue's
+REST API (http://localhost:4566) without needing real Azure credentials.
+
+Resources created:
+- ResourceGroup
+- KeyVault secret
+- Blob container + blob
+- CosmosDB document
+"""
+
+import requests
+import pulumi
+from pulumi import Input, Output
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+
+MINIBLUE_URL = "http://localhost:4566"
+SUBSCRIPTION = "sub1"
+
+
+class ResourceGroupProvider(ResourceProvider):
+    def create(self, props):
+        name = props["name"]
+        location = props.get("location", "eastus")
+        tags = props.get("tags", {})
+        resp = requests.put(
+            f"{MINIBLUE_URL}/subscriptions/{SUBSCRIPTION}/resourcegroups/{name}",
+            json={"location": location, "tags": tags},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        outs = dict(props)
+        outs["provisioning_state"] = data.get("properties", {}).get("provisioningState", "Succeeded")
+        return CreateResult(id_=name, outs=outs)
+
+    def delete(self, id, props):
+        requests.delete(
+            f"{MINIBLUE_URL}/subscriptions/{SUBSCRIPTION}/resourcegroups/{id}"
+        )
+
+
+class ResourceGroup(Resource):
+    def __init__(self, resource_name, name: Input[str], location: Input[str] = "eastus", tags: Input[dict] = None, opts=None):
+        props = {
+            "name": name,
+            "location": location,
+            "tags": tags or {},
+            "provisioning_state": None,
+        }
+        super().__init__(ResourceGroupProvider(), resource_name, props, opts)
+        self.name = self.__dict__.get("name") or Output.from_input(name)
+        self.location = self.__dict__.get("location") or Output.from_input(location)
+        self.provisioning_state = self.__dict__.get("provisioning_state")
+
+
+class KeyVaultSecretProvider(ResourceProvider):
+    def create(self, props):
+        vault = props["vault"]
+        secret_name = props["secret_name"]
+        value = props["value"]
+        resp = requests.put(
+            f"{MINIBLUE_URL}/keyvault/{vault}/secrets/{secret_name}",
+            json={"value": value},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        secret_id = data.get("id", f"https://{vault}.vault.azure.net/secrets/{secret_name}")
+        outs = dict(props)
+        outs["secret_id"] = secret_id
+        return CreateResult(id_=f"{vault}/{secret_name}", outs=outs)
+
+    def delete(self, id, props):
+        vault = props["vault"]
+        secret_name = props["secret_name"]
+        requests.delete(f"{MINIBLUE_URL}/keyvault/{vault}/secrets/{secret_name}")
+
+
+class KeyVaultSecret(Resource):
+    def __init__(self, resource_name, vault: Input[str], secret_name: Input[str], value: Input[str], opts=None):
+        props = {
+            "vault": vault,
+            "secret_name": secret_name,
+            "value": value,
+            "secret_id": None,
+        }
+        super().__init__(KeyVaultSecretProvider(), resource_name, props, opts)
+        self.secret_id = self.__dict__.get("secret_id")
+
+
+class BlobContainerProvider(ResourceProvider):
+    def create(self, props):
+        account = props["account"]
+        container = props["container"]
+        resp = requests.put(f"{MINIBLUE_URL}/blob/{account}/{container}")
+        resp.raise_for_status()
+        return CreateResult(id_=f"{account}/{container}", outs=dict(props))
+
+    def delete(self, id, props):
+        account = props["account"]
+        container = props["container"]
+        requests.delete(f"{MINIBLUE_URL}/blob/{account}/{container}")
+
+
+class BlobContainer(Resource):
+    def __init__(self, resource_name, account: Input[str], container: Input[str], opts=None):
+        props = {"account": account, "container": container}
+        super().__init__(BlobContainerProvider(), resource_name, props, opts)
+
+
+class BlobProvider(ResourceProvider):
+    def create(self, props):
+        account = props["account"]
+        container = props["container"]
+        blob_name = props["blob_name"]
+        content = props.get("content", {})
+        resp = requests.put(
+            f"{MINIBLUE_URL}/blob/{account}/{container}/{blob_name}",
+            json=content,
+        )
+        resp.raise_for_status()
+        return CreateResult(id_=f"{account}/{container}/{blob_name}", outs=dict(props))
+
+    def delete(self, id, props):
+        account = props["account"]
+        container = props["container"]
+        blob_name = props["blob_name"]
+        requests.delete(f"{MINIBLUE_URL}/blob/{account}/{container}/{blob_name}")
+
+
+class Blob(Resource):
+    def __init__(self, resource_name, account: Input[str], container: Input[str], blob_name: Input[str], content: Input[dict] = None, opts=None):
+        props = {
+            "account": account,
+            "container": container,
+            "blob_name": blob_name,
+            "content": content or {},
+        }
+        super().__init__(BlobProvider(), resource_name, props, opts)
+        self.blob_name_out = self.__dict__.get("blob_name") or Output.from_input(blob_name)
+
+
+class CosmosDBDocumentProvider(ResourceProvider):
+    def create(self, props):
+        account = props["account"]
+        db = props["db"]
+        collection = props["collection"]
+        document = props["document"]
+        resp = requests.post(
+            f"{MINIBLUE_URL}/cosmosdb/{account}/dbs/{db}/colls/{collection}/docs",
+            json=document,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        doc_id = document.get("id", data.get("id", "unknown"))
+        outs = dict(props)
+        outs["doc_id"] = doc_id
+        return CreateResult(id_=f"{account}/{db}/{collection}/{doc_id}", outs=outs)
+
+    def delete(self, id, props):
+        account = props["account"]
+        db = props["db"]
+        collection = props["collection"]
+        doc_id = props.get("doc_id", props["document"].get("id"))
+        requests.delete(
+            f"{MINIBLUE_URL}/cosmosdb/{account}/dbs/{db}/colls/{collection}/docs/{doc_id}"
+        )
+
+
+class CosmosDBDocument(Resource):
+    def __init__(self, resource_name, account: Input[str], db: Input[str], collection: Input[str], document: Input[dict], opts=None):
+        props = {
+            "account": account,
+            "db": db,
+            "collection": collection,
+            "document": document,
+            "doc_id": None,
+        }
+        super().__init__(CosmosDBDocumentProvider(), resource_name, props, opts)
+        self.doc_id = self.__dict__.get("doc_id")
+
+
+# ------- Stack resources -------
+
+rg = ResourceGroup(
+    "example-rg",
+    name="pulumi-rg",
+    location="eastus",
+    tags={"managed-by": "pulumi", "env": "dev"},
+)
+
+secret = KeyVaultSecret(
+    "db-password",
+    vault="pulumi-vault",
+    secret_name="db-password",
+    value="pulumi-secret-42",
+    opts=pulumi.ResourceOptions(depends_on=[rg]),
+)
+
+container = BlobContainer(
+    "app-container",
+    account="pulumiaccount",
+    container="appdata",
+    opts=pulumi.ResourceOptions(depends_on=[rg]),
+)
+
+blob = Blob(
+    "config-blob",
+    account="pulumiaccount",
+    container="appdata",
+    blob_name="config.json",
+    content={"env": "dev", "version": "1.0", "managed_by": "pulumi"},
+    opts=pulumi.ResourceOptions(depends_on=[container]),
+)
+
+cosmos_doc = CosmosDBDocument(
+    "user-doc",
+    account="pulumiaccount",
+    db="appdb",
+    collection="users",
+    document={"id": "user1", "name": "Pulumi User", "role": "admin"},
+    opts=pulumi.ResourceOptions(depends_on=[rg]),
+)
+
+# Export outputs
+pulumi.export("resource_group", "pulumi-rg")
+pulumi.export("secret_id", "https://pulumi-vault.vault.azure.net/secrets/db-password")
+pulumi.export("blob_id", "config.json")
+pulumi.export("cosmos_doc_id", "user1")
+pulumi.export("miniblue_url", MINIBLUE_URL)

--- a/examples/pulumi-python/requirements.txt
+++ b/examples/pulumi-python/requirements.txt
@@ -1,0 +1,2 @@
+pulumi>=3.0.0
+requests


### PR DESCRIPTION
## Summary

- **Pulumi Python example** (`examples/pulumi-python/`) - working dynamic provider implementation covering ResourceGroup, KeyVaultSecret, BlobContainer, Blob, and CosmosDBDocument. Tested E2E against miniblue locally.
- **README fixes**: service count updated 19 → 21 (MySQL DB + SQL DB were added but count wasn't updated), Pulumi marked as ✅ done in roadmap
- **CONTRIBUTING.md**: added note that `python3.12-venv` must be installed on Debian/Ubuntu before using Python examples

## Test plan

- [x] `pulumi up --yes` ran successfully against local miniblue server (5 resources created in 1s)
- [x] All 38 existing Go integration tests still pass
- [x] Terraform plan still produces clean output (5 resources)
- [x] Go SDK example still works

## Notes

The Pulumi example uses `pulumi.dynamic.Resource` providers that make direct HTTP calls to miniblue's REST API on `localhost:4566`. No real Azure credentials needed.