### PR TITLE
feat: add ARM paths for ServiceBus, CosmosDB, AppConfig, and Blob

### DIFF
--- a/internal/services/appconfig/handler.go
+++ b/internal/services/appconfig/handler.go
@@ -28,6 +28,17 @@ func NewHandler(s *store.Store) *Handler {
 }
 
 func (h *Handler) Register(r chi.Router) {
+	// ARM-style paths: used by Azure SDKs to enumerate and manage App Configuration stores
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores", func(r chi.Router) {
+		r.Get("/", h.ListStores)
+		r.Route("/{configStoreName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateStore)
+			r.Get("/", h.GetStore)
+			r.Delete("/", h.DeleteStore)
+		})
+	})
+
+	// Data-plane paths: used for key-value operations
 	r.Route("/appconfig/{configStoreName}/kv", func(r chi.Router) {
 		r.Get("/", h.ListKeyValues)
 		r.Route("/{key}", func(r chi.Router) {
@@ -78,5 +89,80 @@ func (h *Handler) DeleteKeyValue(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListKeyValues(w http.ResponseWriter, r *http.Request) {
 	storeName := chi.URLParam(r, "configStoreName")
 	items := h.store.ListByPrefix("appconfig:" + storeName + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+// --- ARM configuration store handlers ---
+
+func (h *Handler) storeARMKey(sub, rg, name string) string {
+	return "appconfig:store:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) buildStoreResponse(sub, rg, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":       "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.AppConfiguration/configurationStores/" + name,
+		"name":     name,
+		"type":     "Microsoft.AppConfiguration/configurationStores",
+		"location": "eastus",
+		"sku": map[string]interface{}{
+			"name": "Standard",
+		},
+		"properties": map[string]interface{}{
+			"provisioningState": "Succeeded",
+			"endpoint":          "https://" + name + ".azconfig.io",
+			"creationDate":      "2026-01-01T00:00:00Z",
+			"disableLocalAuth":  false,
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateStore(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "configStoreName")
+
+	k := h.storeARMKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+
+	store := h.buildStoreResponse(sub, rg, name)
+	h.store.Set(k, store)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(store)
+}
+
+func (h *Handler) GetStore(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "configStoreName")
+
+	v, ok := h.store.Get(h.storeARMKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.AppConfiguration/configurationStores", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteStore(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "configStoreName")
+
+	if !h.store.Delete(h.storeARMKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.AppConfiguration/configurationStores", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListStores(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("appconfig:store:" + sub + ":" + rg + ":")
 	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }

--- a/internal/services/blob/handler.go
+++ b/internal/services/blob/handler.go
@@ -32,6 +32,25 @@ func NewHandler(s *store.Store) *Handler {
 }
 
 func (h *Handler) Register(r chi.Router) {
+	// ARM-style paths: used by Azure SDKs to enumerate and manage storage accounts
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts", func(r chi.Router) {
+		r.Get("/", h.ListStorageAccounts)
+		r.Route("/{accountName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateStorageAccount)
+			r.Get("/", h.GetStorageAccount)
+			r.Delete("/", h.DeleteStorageAccount)
+			r.Route("/blobServices/default/containers", func(r chi.Router) {
+				r.Get("/", h.ListContainersARM)
+				r.Route("/{containerName}", func(r chi.Router) {
+					r.Put("/", h.CreateContainerARM)
+					r.Get("/", h.GetContainerARM)
+					r.Delete("/", h.DeleteContainerARM)
+				})
+			})
+		})
+	})
+
+	// Data-plane paths: used for blob operations
 	r.Route("/blob/{accountName}", func(r chi.Router) {
 		r.Route("/{containerName}", func(r chi.Router) {
 			r.Put("/", h.CreateContainer)
@@ -131,4 +150,165 @@ func (h *Handler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 	blobName := chi.URLParam(r, "blobName")
 	h.store.Delete(h.blobKey(account, container, blobName))
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// --- ARM storage account handlers ---
+
+func (h *Handler) storageAccountKey(sub, rg, name string) string {
+	return "blob:account:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) buildStorageAccountResponse(sub, rg, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":       "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Storage/storageAccounts/" + name,
+		"name":     name,
+		"type":     "Microsoft.Storage/storageAccounts",
+		"location": "eastus",
+		"sku": map[string]interface{}{
+			"name": "Standard_LRS",
+			"tier": "Standard",
+		},
+		"kind": "StorageV2",
+		"properties": map[string]interface{}{
+			"provisioningState":        "Succeeded",
+			"primaryEndpoints": map[string]interface{}{
+				"blob":  "https://" + name + ".blob.core.windows.net/",
+				"queue": "https://" + name + ".queue.core.windows.net/",
+				"table": "https://" + name + ".table.core.windows.net/",
+				"file":  "https://" + name + ".file.core.windows.net/",
+			},
+			"primaryLocation":          "eastus",
+			"statusOfPrimary":          "available",
+			"supportsHttpsTrafficOnly": true,
+			"creationTime":             "2026-01-01T00:00:00Z",
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateStorageAccount(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "accountName")
+
+	k := h.storageAccountKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+
+	acct := h.buildStorageAccountResponse(sub, rg, name)
+	h.store.Set(k, acct)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(acct)
+}
+
+func (h *Handler) GetStorageAccount(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "accountName")
+
+	v, ok := h.store.Get(h.storageAccountKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Storage/storageAccounts", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteStorageAccount(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "accountName")
+
+	if !h.store.Delete(h.storageAccountKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Storage/storageAccounts", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListStorageAccounts(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("blob:account:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+// --- ARM blob container handlers ---
+
+func (h *Handler) armContainerKey(sub, rg, account, name string) string {
+	return "blob:armcontainer:" + sub + ":" + rg + ":" + account + ":" + name
+}
+
+func (h *Handler) buildARMContainerResponse(sub, rg, account, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Storage/storageAccounts/" + account + "/blobServices/default/containers/" + name,
+		"name": name,
+		"type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+		"properties": map[string]interface{}{
+			"publicAccess":      "None",
+			"leaseStatus":       "Unlocked",
+			"leaseState":        "Available",
+			"lastModifiedTime":  fmt.Sprintf("\"0x%X\"", time.Now().UnixNano()),
+			"hasImmutabilityPolicy": false,
+			"hasLegalHold":          false,
+		},
+	}
+}
+
+func (h *Handler) CreateContainerARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	account := chi.URLParam(r, "accountName")
+	name := chi.URLParam(r, "containerName")
+
+	k := h.armContainerKey(sub, rg, account, name)
+	_, exists := h.store.Get(k)
+
+	c := h.buildARMContainerResponse(sub, rg, account, name)
+	h.store.Set(k, c)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(c)
+}
+
+func (h *Handler) GetContainerARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	account := chi.URLParam(r, "accountName")
+	name := chi.URLParam(r, "containerName")
+
+	v, ok := h.store.Get(h.armContainerKey(sub, rg, account, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Storage/storageAccounts/blobServices/containers", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteContainerARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	account := chi.URLParam(r, "accountName")
+	name := chi.URLParam(r, "containerName")
+
+	if !h.store.Delete(h.armContainerKey(sub, rg, account, name)) {
+		azerr.NotFound(w, "Microsoft.Storage/storageAccounts/blobServices/containers", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListContainersARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	account := chi.URLParam(r, "accountName")
+	items := h.store.ListByPrefix("blob:armcontainer:" + sub + ":" + rg + ":" + account + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }

--- a/internal/services/cosmosdb/handler.go
+++ b/internal/services/cosmosdb/handler.go
@@ -18,6 +18,33 @@ func NewHandler(s *store.Store) *Handler {
 }
 
 func (h *Handler) Register(r chi.Router) {
+	// ARM-style paths: used by Azure SDKs to enumerate and manage Cosmos DB accounts
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts", func(r chi.Router) {
+		r.Get("/", h.ListAccounts)
+		r.Route("/{accountName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateAccount)
+			r.Get("/", h.GetAccount)
+			r.Delete("/", h.DeleteAccount)
+			r.Route("/sqlDatabases", func(r chi.Router) {
+				r.Get("/", h.ListSQLDatabases)
+				r.Route("/{dbName}", func(r chi.Router) {
+					r.Put("/", h.CreateOrUpdateSQLDatabase)
+					r.Get("/", h.GetSQLDatabase)
+					r.Delete("/", h.DeleteSQLDatabase)
+					r.Route("/containers", func(r chi.Router) {
+						r.Get("/", h.ListContainers)
+						r.Route("/{containerName}", func(r chi.Router) {
+							r.Put("/", h.CreateOrUpdateContainer)
+							r.Get("/", h.GetContainer)
+							r.Delete("/", h.DeleteContainer)
+						})
+					})
+				})
+			})
+		})
+	})
+
+	// Data-plane paths: used for document operations
 	r.Route("/cosmosdb/{accountName}/dbs/{dbName}/colls/{collName}/docs", func(r chi.Router) {
 		r.Post("/", h.CreateDocument)
 		r.Get("/", h.QueryDocuments)
@@ -96,4 +123,228 @@ func (h *Handler) QueryDocuments(w http.ResponseWriter, r *http.Request) {
 	coll := chi.URLParam(r, "collName")
 	items := h.store.ListByPrefix("cosmos:" + account + ":" + db + ":" + coll + ":")
 	json.NewEncoder(w).Encode(map[string]interface{}{"Documents": items, "_count": len(items)})
+}
+
+// --- ARM account handlers ---
+
+func (h *Handler) accountKey(sub, rg, name string) string {
+	return "cosmos:account:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) buildAccountResponse(sub, rg, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":       "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.DocumentDB/databaseAccounts/" + name,
+		"name":     name,
+		"type":     "Microsoft.DocumentDB/databaseAccounts",
+		"location": "eastus",
+		"kind":     "GlobalDocumentDB",
+		"properties": map[string]interface{}{
+			"provisioningState":     "Succeeded",
+			"documentEndpoint":      "https://" + name + ".documents.azure.com:443/",
+			"databaseAccountOfferType": "Standard",
+			"consistencyPolicy": map[string]interface{}{
+				"defaultConsistencyLevel": "Session",
+			},
+			"locations": []map[string]interface{}{
+				{"locationName": "East US", "failoverPriority": 0, "isZoneRedundant": false},
+			},
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateAccount(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "accountName")
+
+	k := h.accountKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+
+	acct := h.buildAccountResponse(sub, rg, name)
+	h.store.Set(k, acct)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(acct)
+}
+
+func (h *Handler) GetAccount(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "accountName")
+
+	v, ok := h.store.Get(h.accountKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.DocumentDB/databaseAccounts", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "accountName")
+
+	if !h.store.Delete(h.accountKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.DocumentDB/databaseAccounts", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListAccounts(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("cosmos:account:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+// --- ARM SQL Database handlers ---
+
+func (h *Handler) sqlDbKey(sub, rg, acct, dbName string) string {
+	return "cosmos:sqldb:" + sub + ":" + rg + ":" + acct + ":" + dbName
+}
+
+func (h *Handler) CreateOrUpdateSQLDatabase(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	dbName := chi.URLParam(r, "dbName")
+
+	k := h.sqlDbKey(sub, rg, acct, dbName)
+	_, exists := h.store.Get(k)
+
+	db := map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.DocumentDB/databaseAccounts/" + acct + "/sqlDatabases/" + dbName,
+		"name": dbName,
+		"type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+		"properties": map[string]interface{}{
+			"resource": map[string]interface{}{"id": dbName},
+		},
+	}
+	h.store.Set(k, db)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(db)
+}
+
+func (h *Handler) GetSQLDatabase(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	dbName := chi.URLParam(r, "dbName")
+
+	v, ok := h.store.Get(h.sqlDbKey(sub, rg, acct, dbName))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases", dbName)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteSQLDatabase(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	dbName := chi.URLParam(r, "dbName")
+
+	if !h.store.Delete(h.sqlDbKey(sub, rg, acct, dbName)) {
+		azerr.NotFound(w, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases", dbName)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListSQLDatabases(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	items := h.store.ListByPrefix("cosmos:sqldb:" + sub + ":" + rg + ":" + acct + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+// --- ARM Container handlers ---
+
+func (h *Handler) containerKey(sub, rg, acct, dbName, name string) string {
+	return "cosmos:container:" + sub + ":" + rg + ":" + acct + ":" + dbName + ":" + name
+}
+
+func (h *Handler) CreateOrUpdateContainer(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	dbName := chi.URLParam(r, "dbName")
+	name := chi.URLParam(r, "containerName")
+
+	k := h.containerKey(sub, rg, acct, dbName, name)
+	_, exists := h.store.Get(k)
+
+	c := map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.DocumentDB/databaseAccounts/" + acct + "/sqlDatabases/" + dbName + "/containers/" + name,
+		"name": name,
+		"type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+		"properties": map[string]interface{}{
+			"resource": map[string]interface{}{
+				"id": name,
+				"partitionKey": map[string]interface{}{
+					"paths": []string{"/id"},
+					"kind":  "Hash",
+				},
+			},
+		},
+	}
+	h.store.Set(k, c)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(c)
+}
+
+func (h *Handler) GetContainer(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	dbName := chi.URLParam(r, "dbName")
+	name := chi.URLParam(r, "containerName")
+
+	v, ok := h.store.Get(h.containerKey(sub, rg, acct, dbName, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteContainer(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	dbName := chi.URLParam(r, "dbName")
+	name := chi.URLParam(r, "containerName")
+
+	if !h.store.Delete(h.containerKey(sub, rg, acct, dbName, name)) {
+		azerr.NotFound(w, "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListContainers(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	acct := chi.URLParam(r, "accountName")
+	dbName := chi.URLParam(r, "dbName")
+	items := h.store.ListByPrefix("cosmos:container:" + sub + ":" + rg + ":" + acct + ":" + dbName + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }

--- a/internal/services/servicebus/handler.go
+++ b/internal/services/servicebus/handler.go
@@ -42,6 +42,33 @@ func NewHandler(s *store.Store) *Handler {
 }
 
 func (h *Handler) Register(r chi.Router) {
+	// ARM-style paths: used by Azure SDKs to enumerate and manage resources
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces", func(r chi.Router) {
+		r.Get("/", h.ListNamespaces)
+		r.Route("/{namespaceName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateNamespace)
+			r.Get("/", h.GetNamespace)
+			r.Delete("/", h.DeleteNamespace)
+			r.Route("/queues", func(r chi.Router) {
+				r.Get("/", h.ListQueuesARM)
+				r.Route("/{queueName}", func(r chi.Router) {
+					r.Put("/", h.CreateQueueARM)
+					r.Get("/", h.GetQueueARM)
+					r.Delete("/", h.DeleteQueueARM)
+				})
+			})
+			r.Route("/topics", func(r chi.Router) {
+				r.Get("/", h.ListTopicsARM)
+				r.Route("/{topicName}", func(r chi.Router) {
+					r.Put("/", h.CreateTopicARM)
+					r.Get("/", h.GetTopicARM)
+					r.Delete("/", h.DeleteTopicARM)
+				})
+			})
+		})
+	})
+
+	// Data-plane paths: used for messaging operations (send/receive)
 	r.Route("/servicebus/{namespace}", func(r chi.Router) {
 		r.Route("/queues", func(r chi.Router) {
 			r.Get("/", h.ListQueues)
@@ -178,6 +205,233 @@ func (h *Handler) ReceiveMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// --- ARM namespace handlers ---
+
+func (h *Handler) namespaceKey(sub, rg, name string) string {
+	return "sb:namespace:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) buildNamespaceResponse(sub, rg, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":       "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.ServiceBus/namespaces/" + name,
+		"name":     name,
+		"type":     "Microsoft.ServiceBus/namespaces",
+		"location": "eastus",
+		"sku": map[string]interface{}{
+			"name": "Standard",
+			"tier": "Standard",
+		},
+		"properties": map[string]interface{}{
+			"provisioningState":       "Succeeded",
+			"status":                  "Active",
+			"serviceBusEndpoint":      "https://" + name + ".servicebus.windows.net:443/",
+			"metricId":                sub + ":" + name,
+			"createdAt":               "2026-01-01T00:00:00Z",
+			"updatedAt":               "2026-01-01T00:00:00Z",
+			"disableLocalAuth":        false,
+			"zoneRedundant":           false,
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateNamespace(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "namespaceName")
+
+	k := h.namespaceKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+
+	ns := h.buildNamespaceResponse(sub, rg, name)
+	h.store.Set(k, ns)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(ns)
+}
+
+func (h *Handler) GetNamespace(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "namespaceName")
+
+	v, ok := h.store.Get(h.namespaceKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.ServiceBus/namespaces", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteNamespace(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "namespaceName")
+
+	if !h.store.Delete(h.namespaceKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.ServiceBus/namespaces", name)
+		return
+	}
+	h.store.DeleteByPrefix("sb:queue:" + name + ":")
+	h.store.DeleteByPrefix("sb:topic:" + name + ":")
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListNamespaces(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("sb:namespace:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+func (h *Handler) armQueueKey(sub, rg, ns, name string) string {
+	return "sb:armqueue:" + sub + ":" + rg + ":" + ns + ":" + name
+}
+
+func (h *Handler) buildARMQueueResponse(sub, rg, ns, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.ServiceBus/namespaces/" + ns + "/queues/" + name,
+		"name": name,
+		"type": "Microsoft.ServiceBus/namespaces/queues",
+		"properties": map[string]interface{}{
+			"status":                  "Active",
+			"messageCount":            0,
+			"maxDeliveryCount":        10,
+			"defaultMessageTimeToLive": "P14D",
+			"lockDuration":            "PT1M",
+			"createdAt":               "2026-01-01T00:00:00Z",
+		},
+	}
+}
+
+func (h *Handler) CreateQueueARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	name := chi.URLParam(r, "queueName")
+
+	k := h.armQueueKey(sub, rg, ns, name)
+	_, exists := h.store.Get(k)
+
+	q := h.buildARMQueueResponse(sub, rg, ns, name)
+	h.store.Set(k, q)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(q)
+}
+
+func (h *Handler) GetQueueARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	name := chi.URLParam(r, "queueName")
+
+	v, ok := h.store.Get(h.armQueueKey(sub, rg, ns, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.ServiceBus/namespaces/queues", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteQueueARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	name := chi.URLParam(r, "queueName")
+
+	if !h.store.Delete(h.armQueueKey(sub, rg, ns, name)) {
+		azerr.NotFound(w, "Microsoft.ServiceBus/namespaces/queues", name)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) ListQueuesARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	items := h.store.ListByPrefix("sb:armqueue:" + sub + ":" + rg + ":" + ns + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+func (h *Handler) armTopicKey(sub, rg, ns, name string) string {
+	return "sb:armtopic:" + sub + ":" + rg + ":" + ns + ":" + name
+}
+
+func (h *Handler) CreateTopicARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	name := chi.URLParam(r, "topicName")
+
+	k := h.armTopicKey(sub, rg, ns, name)
+	_, exists := h.store.Get(k)
+
+	t := map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.ServiceBus/namespaces/" + ns + "/topics/" + name,
+		"name": name,
+		"type": "Microsoft.ServiceBus/namespaces/topics",
+		"properties": map[string]interface{}{
+			"status":                  "Active",
+			"defaultMessageTimeToLive": "P14D",
+			"createdAt":               "2026-01-01T00:00:00Z",
+		},
+	}
+	h.store.Set(k, t)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(t)
+}
+
+func (h *Handler) GetTopicARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	name := chi.URLParam(r, "topicName")
+
+	v, ok := h.store.Get(h.armTopicKey(sub, rg, ns, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.ServiceBus/namespaces/topics", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteTopicARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	name := chi.URLParam(r, "topicName")
+
+	if !h.store.Delete(h.armTopicKey(sub, rg, ns, name)) {
+		azerr.NotFound(w, "Microsoft.ServiceBus/namespaces/topics", name)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) ListTopicsARM(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	ns := chi.URLParam(r, "namespaceName")
+	items := h.store.ListByPrefix("sb:armtopic:" + sub + ":" + rg + ":" + ns + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+// --- Data-plane topic handlers (legacy) ---
 
 func (h *Handler) CreateTopic(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)

--- a/tests/appconfig_arm_test.go
+++ b/tests/appconfig_arm_test.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"testing"
+)
+
+const appConfigSub = "sub1"
+const appConfigRG = "rg1"
+const appConfigStore = "myappconfig"
+
+func appConfigARMBase(ts interface{ URL string }) string {
+	return ts.URL + "/subscriptions/" + appConfigSub + "/resourceGroups/" + appConfigRG + "/providers/Microsoft.AppConfiguration/configurationStores"
+}
+
+func TestAppConfigARMStoreCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := appConfigARMBase(ts) + "/" + appConfigStore
+
+	// Create store
+	resp := doRequest(t, "PUT", base, `{"location":"eastus","sku":{"name":"Standard"}}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != appConfigStore {
+		t.Fatalf("expected name=%s, got %v", appConfigStore, m["name"])
+	}
+	if m["type"] != "Microsoft.AppConfiguration/configurationStores" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded, got %v", props["provisioningState"])
+	}
+	if props["endpoint"] == nil {
+		t.Fatal("expected endpoint in properties")
+	}
+
+	// Get store
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// Update store (idempotent)
+	resp3 := doRequest(t, "PUT", base, `{"location":"eastus"}`)
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+}
+
+func TestAppConfigARMStoreList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := appConfigARMBase(ts)
+
+	doRequest(t, "PUT", base+"/store-a", `{}`).Body.Close()
+	doRequest(t, "PUT", base+"/store-b", `{}`).Body.Close()
+
+	resp := doRequest(t, "GET", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	items := m["value"].([]interface{})
+	if len(items) < 2 {
+		t.Fatalf("expected at least 2 stores, got %d", len(items))
+	}
+}
+
+func TestAppConfigARMStoreNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	resp := doRequest(t, "GET", appConfigARMBase(ts)+"/nonexistent", "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 404)
+}
+
+func TestAppConfigARMStoreDelete(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := appConfigARMBase(ts) + "/store-del"
+
+	doRequest(t, "PUT", base, `{}`).Body.Close()
+
+	resp := doRequest(t, "DELETE", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 202)
+
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 404)
+}
+
+func TestAppConfigARMResponseHasID(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := appConfigARMBase(ts) + "/mystore"
+
+	resp := doRequest(t, "PUT", base, `{}`)
+	defer resp.Body.Close()
+	m := decodeJSON(t, resp)
+
+	expectedID := "/subscriptions/" + appConfigSub + "/resourceGroups/" + appConfigRG + "/providers/Microsoft.AppConfiguration/configurationStores/mystore"
+	if m["id"] != expectedID {
+		t.Fatalf("expected id=%s, got %v", expectedID, m["id"])
+	}
+}
+
+func TestAppConfigARMEndpointFormat(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	storeName := "teststoreendpt"
+	base := appConfigARMBase(ts) + "/" + storeName
+
+	resp := doRequest(t, "PUT", base, `{}`)
+	defer resp.Body.Close()
+	m := decodeJSON(t, resp)
+	props := m["properties"].(map[string]interface{})
+
+	expectedEndpoint := "https://" + storeName + ".azconfig.io"
+	if props["endpoint"] != expectedEndpoint {
+		t.Fatalf("expected endpoint=%s, got %v", expectedEndpoint, props["endpoint"])
+	}
+}
+
+func TestAppConfigARMDoesNotBreakDataPlane(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/appconfig/mystore/kv"
+
+	// Data-plane operations should still work
+	resp := doRequest(t, "PUT", base+"/mykey", `{"value":"myvalue"}`)
+	defer resp.Body.Close()
+	m := decodeJSON(t, resp)
+	if m["value"] != "myvalue" {
+		t.Fatalf("expected value=myvalue, got %v", m["value"])
+	}
+}

--- a/tests/blob_arm_test.go
+++ b/tests/blob_arm_test.go
@@ -1,0 +1,188 @@
+package tests
+
+import (
+	"testing"
+)
+
+const blobSub = "sub1"
+const blobRG = "rg1"
+const blobAcct = "mystorageacct"
+
+func blobARMBase(ts interface{ URL string }) string {
+	return ts.URL + "/subscriptions/" + blobSub + "/resourceGroups/" + blobRG + "/providers/Microsoft.Storage/storageAccounts"
+}
+
+func TestBlobARMStorageAccountCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := blobARMBase(ts) + "/" + blobAcct
+
+	// Create account
+	resp := doRequest(t, "PUT", base, `{"location":"eastus","sku":{"name":"Standard_LRS"},"kind":"StorageV2"}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != blobAcct {
+		t.Fatalf("expected name=%s, got %v", blobAcct, m["name"])
+	}
+	if m["type"] != "Microsoft.Storage/storageAccounts" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded, got %v", props["provisioningState"])
+	}
+	endpoints := props["primaryEndpoints"].(map[string]interface{})
+	if endpoints["blob"] == nil {
+		t.Fatal("expected blob endpoint in primaryEndpoints")
+	}
+
+	// Get account
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// Update account (idempotent)
+	resp3 := doRequest(t, "PUT", base, `{"location":"eastus"}`)
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+}
+
+func TestBlobARMStorageAccountList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := blobARMBase(ts)
+
+	doRequest(t, "PUT", base+"/acct-a", `{}`).Body.Close()
+	doRequest(t, "PUT", base+"/acct-b", `{}`).Body.Close()
+
+	resp := doRequest(t, "GET", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	items := m["value"].([]interface{})
+	if len(items) < 2 {
+		t.Fatalf("expected at least 2 accounts, got %d", len(items))
+	}
+}
+
+func TestBlobARMStorageAccountNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	resp := doRequest(t, "GET", blobARMBase(ts)+"/nonexistent", "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 404)
+}
+
+func TestBlobARMStorageAccountDelete(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := blobARMBase(ts) + "/acct-del"
+
+	doRequest(t, "PUT", base, `{}`).Body.Close()
+
+	resp := doRequest(t, "DELETE", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 202)
+
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 404)
+}
+
+func TestBlobARMContainerCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	acctBase := blobARMBase(ts) + "/" + blobAcct
+	doRequest(t, "PUT", acctBase, `{}`).Body.Close()
+
+	cBase := acctBase + "/blobServices/default/containers/mycontainer"
+
+	// Create container
+	resp := doRequest(t, "PUT", cBase, `{}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != "mycontainer" {
+		t.Fatalf("expected name=mycontainer, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.Storage/storageAccounts/blobServices/containers" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+
+	// Get container
+	resp2 := doRequest(t, "GET", cBase, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// List containers
+	resp3 := doRequest(t, "GET", acctBase+"/blobServices/default/containers", "")
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+	ml := decodeJSON(t, resp3)
+	if len(ml["value"].([]interface{})) == 0 {
+		t.Fatal("expected at least 1 container in list")
+	}
+
+	// Delete container
+	resp4 := doRequest(t, "DELETE", cBase, "")
+	defer resp4.Body.Close()
+	expectStatus(t, resp4, 202)
+
+	resp5 := doRequest(t, "GET", cBase, "")
+	defer resp5.Body.Close()
+	expectStatus(t, resp5, 404)
+}
+
+func TestBlobARMResponseHasID(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := blobARMBase(ts) + "/myacct"
+
+	resp := doRequest(t, "PUT", base, `{}`)
+	defer resp.Body.Close()
+	m := decodeJSON(t, resp)
+
+	expectedID := "/subscriptions/" + blobSub + "/resourceGroups/" + blobRG + "/providers/Microsoft.Storage/storageAccounts/myacct"
+	if m["id"] != expectedID {
+		t.Fatalf("expected id=%s, got %v", expectedID, m["id"])
+	}
+}
+
+func TestBlobARMPrimaryEndpointFormat(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	acctName := "endpttestacct"
+	base := blobARMBase(ts) + "/" + acctName
+
+	resp := doRequest(t, "PUT", base, `{}`)
+	defer resp.Body.Close()
+	m := decodeJSON(t, resp)
+	props := m["properties"].(map[string]interface{})
+	endpoints := props["primaryEndpoints"].(map[string]interface{})
+
+	expected := "https://" + acctName + ".blob.core.windows.net/"
+	if endpoints["blob"] != expected {
+		t.Fatalf("expected blob endpoint=%s, got %v", expected, endpoints["blob"])
+	}
+}
+
+func TestBlobARMDoesNotBreakDataPlane(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/blob/myaccount/mycontainer"
+
+	// Data-plane operations should still work
+	doRequest(t, "PUT", base, "").Body.Close()
+
+	resp := doRequest(t, "PUT", base+"/hello.txt", "data")
+	resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	resp2 := doRequest(t, "GET", base+"/hello.txt", "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+}

--- a/tests/cosmosdb_arm_test.go
+++ b/tests/cosmosdb_arm_test.go
@@ -1,0 +1,198 @@
+package tests
+
+import (
+	"testing"
+)
+
+const cosmosSub = "sub1"
+const cosmosRG = "rg1"
+const cosmosAcct = "mycosmosacct"
+
+func cosmosARMBase(ts interface{ URL string }) string {
+	return ts.URL + "/subscriptions/" + cosmosSub + "/resourceGroups/" + cosmosRG + "/providers/Microsoft.DocumentDB/databaseAccounts"
+}
+
+func TestCosmosDBARMAccountCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := cosmosARMBase(ts) + "/" + cosmosAcct
+
+	// Create account
+	resp := doRequest(t, "PUT", base, `{"location":"eastus","kind":"GlobalDocumentDB"}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != cosmosAcct {
+		t.Fatalf("expected name=%s, got %v", cosmosAcct, m["name"])
+	}
+	if m["type"] != "Microsoft.DocumentDB/databaseAccounts" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded, got %v", props["provisioningState"])
+	}
+	if props["documentEndpoint"] == nil {
+		t.Fatal("expected documentEndpoint in properties")
+	}
+
+	// Get account
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// Update account (idempotent)
+	resp3 := doRequest(t, "PUT", base, `{"location":"eastus"}`)
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+}
+
+func TestCosmosDBARMAccountList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := cosmosARMBase(ts)
+
+	doRequest(t, "PUT", base+"/acct-a", `{}`).Body.Close()
+	doRequest(t, "PUT", base+"/acct-b", `{}`).Body.Close()
+
+	resp := doRequest(t, "GET", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	items := m["value"].([]interface{})
+	if len(items) < 2 {
+		t.Fatalf("expected at least 2 accounts, got %d", len(items))
+	}
+}
+
+func TestCosmosDBARMAccountNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	resp := doRequest(t, "GET", cosmosARMBase(ts)+"/nonexistent", "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 404)
+}
+
+func TestCosmosDBARMAccountDelete(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := cosmosARMBase(ts) + "/acct-del"
+
+	doRequest(t, "PUT", base, `{}`).Body.Close()
+
+	resp := doRequest(t, "DELETE", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 202)
+
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 404)
+}
+
+func TestCosmosDBARMSQLDatabaseCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	acctBase := cosmosARMBase(ts) + "/" + cosmosAcct
+	doRequest(t, "PUT", acctBase, `{}`).Body.Close()
+
+	dbBase := acctBase + "/sqlDatabases/mydb"
+
+	// Create database
+	resp := doRequest(t, "PUT", dbBase, `{}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != "mydb" {
+		t.Fatalf("expected name=mydb, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.DocumentDB/databaseAccounts/sqlDatabases" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+
+	// Get database
+	resp2 := doRequest(t, "GET", dbBase, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// List databases
+	resp3 := doRequest(t, "GET", acctBase+"/sqlDatabases", "")
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+	ml := decodeJSON(t, resp3)
+	if len(ml["value"].([]interface{})) == 0 {
+		t.Fatal("expected at least 1 database in list")
+	}
+
+	// Delete database
+	resp4 := doRequest(t, "DELETE", dbBase, "")
+	defer resp4.Body.Close()
+	expectStatus(t, resp4, 202)
+
+	resp5 := doRequest(t, "GET", dbBase, "")
+	defer resp5.Body.Close()
+	expectStatus(t, resp5, 404)
+}
+
+func TestCosmosDBARMContainerCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	acctBase := cosmosARMBase(ts) + "/" + cosmosAcct
+	doRequest(t, "PUT", acctBase, `{}`).Body.Close()
+	doRequest(t, "PUT", acctBase+"/sqlDatabases/mydb", `{}`).Body.Close()
+
+	cBase := acctBase + "/sqlDatabases/mydb/containers/users"
+
+	// Create container
+	resp := doRequest(t, "PUT", cBase, `{}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != "users" {
+		t.Fatalf("expected name=users, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+
+	// Get container
+	resp2 := doRequest(t, "GET", cBase, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// List containers
+	resp3 := doRequest(t, "GET", acctBase+"/sqlDatabases/mydb/containers", "")
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+	ml := decodeJSON(t, resp3)
+	if len(ml["value"].([]interface{})) == 0 {
+		t.Fatal("expected at least 1 container in list")
+	}
+
+	// Delete container
+	resp4 := doRequest(t, "DELETE", cBase, "")
+	defer resp4.Body.Close()
+	expectStatus(t, resp4, 202)
+
+	resp5 := doRequest(t, "GET", cBase, "")
+	defer resp5.Body.Close()
+	expectStatus(t, resp5, 404)
+}
+
+func TestCosmosDBARMResponseHasID(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := cosmosARMBase(ts) + "/myacct"
+
+	resp := doRequest(t, "PUT", base, `{}`)
+	defer resp.Body.Close()
+	m := decodeJSON(t, resp)
+
+	expectedID := "/subscriptions/" + cosmosSub + "/resourceGroups/" + cosmosRG + "/providers/Microsoft.DocumentDB/databaseAccounts/myacct"
+	if m["id"] != expectedID {
+		t.Fatalf("expected id=%s, got %v", expectedID, m["id"])
+	}
+}

--- a/tests/servicebus_arm_test.go
+++ b/tests/servicebus_arm_test.go
@@ -1,0 +1,194 @@
+package tests
+
+import (
+	"testing"
+)
+
+const sbSub = "sub1"
+const sbRG = "rg1"
+const sbNS = "mynamespace"
+
+func sbARMBase(ts interface{ URL string }) string {
+	return ts.URL + "/subscriptions/" + sbSub + "/resourceGroups/" + sbRG + "/providers/Microsoft.ServiceBus/namespaces"
+}
+
+func TestServiceBusARMNamespaceCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := sbARMBase(ts) + "/" + sbNS
+
+	// Create namespace
+	resp := doRequest(t, "PUT", base, `{"location":"eastus","sku":{"name":"Standard"}}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != sbNS {
+		t.Fatalf("expected name=%s, got %v", sbNS, m["name"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded, got %v", props["provisioningState"])
+	}
+	if m["type"] != "Microsoft.ServiceBus/namespaces" {
+		t.Fatalf("expected type=Microsoft.ServiceBus/namespaces, got %v", m["type"])
+	}
+
+	// Get namespace
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// Update namespace (idempotent)
+	resp3 := doRequest(t, "PUT", base, `{"location":"eastus"}`)
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+}
+
+func TestServiceBusARMNamespaceList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := sbARMBase(ts)
+
+	doRequest(t, "PUT", base+"/ns-a", `{}`).Body.Close()
+	doRequest(t, "PUT", base+"/ns-b", `{}`).Body.Close()
+
+	resp := doRequest(t, "GET", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	items := m["value"].([]interface{})
+	if len(items) < 2 {
+		t.Fatalf("expected at least 2 namespaces, got %d", len(items))
+	}
+}
+
+func TestServiceBusARMNamespaceNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := sbARMBase(ts) + "/nonexistent"
+
+	resp := doRequest(t, "GET", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 404)
+}
+
+func TestServiceBusARMNamespaceDelete(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := sbARMBase(ts) + "/ns-to-delete"
+
+	doRequest(t, "PUT", base, `{}`).Body.Close()
+
+	resp := doRequest(t, "DELETE", base, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 202)
+
+	resp2 := doRequest(t, "GET", base, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 404)
+}
+
+func TestServiceBusARMQueueCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	nsBase := sbARMBase(ts) + "/" + sbNS
+	doRequest(t, "PUT", nsBase, `{}`).Body.Close()
+
+	qBase := nsBase + "/queues/orders"
+
+	// Create queue
+	resp := doRequest(t, "PUT", qBase, `{}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != "orders" {
+		t.Fatalf("expected name=orders, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.ServiceBus/namespaces/queues" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+
+	// Get queue
+	resp2 := doRequest(t, "GET", qBase, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// List queues
+	resp3 := doRequest(t, "GET", nsBase+"/queues", "")
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+	ml := decodeJSON(t, resp3)
+	if len(ml["value"].([]interface{})) == 0 {
+		t.Fatal("expected at least 1 queue in list")
+	}
+
+	// Delete queue
+	resp4 := doRequest(t, "DELETE", qBase, "")
+	defer resp4.Body.Close()
+	expectStatus(t, resp4, 200)
+
+	// Get deleted queue = 404
+	resp5 := doRequest(t, "GET", qBase, "")
+	defer resp5.Body.Close()
+	expectStatus(t, resp5, 404)
+}
+
+func TestServiceBusARMTopicCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	nsBase := sbARMBase(ts) + "/" + sbNS
+	doRequest(t, "PUT", nsBase, `{}`).Body.Close()
+
+	tBase := nsBase + "/topics/events"
+
+	// Create topic
+	resp := doRequest(t, "PUT", tBase, `{}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	if m["name"] != "events" {
+		t.Fatalf("expected name=events, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.ServiceBus/namespaces/topics" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+
+	// Get topic
+	resp2 := doRequest(t, "GET", tBase, "")
+	defer resp2.Body.Close()
+	expectStatus(t, resp2, 200)
+
+	// List topics
+	resp3 := doRequest(t, "GET", nsBase+"/topics", "")
+	defer resp3.Body.Close()
+	expectStatus(t, resp3, 200)
+
+	// Delete topic
+	resp4 := doRequest(t, "DELETE", tBase, "")
+	defer resp4.Body.Close()
+	expectStatus(t, resp4, 200)
+
+	// Get deleted topic = 404
+	resp5 := doRequest(t, "GET", tBase, "")
+	defer resp5.Body.Close()
+	expectStatus(t, resp5, 404)
+}
+
+func TestServiceBusARMResponseHasID(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := sbARMBase(ts) + "/myns"
+
+	resp := doRequest(t, "PUT", base, `{}`)
+	defer resp.Body.Close()
+	m := decodeJSON(t, resp)
+
+	expectedID := "/subscriptions/" + sbSub + "/resourceGroups/" + sbRG + "/providers/Microsoft.ServiceBus/namespaces/myns"
+	if m["id"] != expectedID {
+		t.Fatalf("expected id=%s, got %v", expectedID, m["id"])
+	}
+}


### PR DESCRIPTION
## Problem

ServiceBus, CosmosDB, AppConfig, and Blob were missing standard ARM paths (`/subscriptions/{sub}/resourceGroups/{rg}/providers/...`). Azure SDKs rely on these paths to enumerate and manage resources.

## Changes

- **ServiceBus**: `Microsoft.ServiceBus/namespaces` CRUD + nested queues/topics
- **CosmosDB**: `Microsoft.DocumentDB/databaseAccounts` CRUD + nested databases/containers
- **AppConfig**: `Microsoft.AppConfiguration/configurationStores` CRUD
- **Blob**: `Microsoft.Storage/storageAccounts` CRUD + blobServices/containers

All existing data-plane paths preserved. ARM integration tests added for all 4 services.