### PR TITLE
fix: Workflow triggers and E2E test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,23 +6,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      miniblue:
-        image: moabukar/miniblue:latest
-        ports:
-          - 4566:4566
-          - 4567:4567
-        options: --health-cmd="/healthcheck" --health-interval=5s --health-retries=12 --health-start-period=15s
-
     steps:
       - uses: actions/checkout@v6
 
-      - name: Wait for miniblue
+      - name: Start miniblue
         run: |
+          docker run -d --name miniblue -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
           for i in $(seq 1 30); do
             curl -sf http://localhost:4566/health && break
             sleep 1
           done
+          curl -sf http://localhost:4566/health
 
       - name: Health check
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   push:
-    branches: [main]
     tags: ['v*']
 
 jobs:


### PR DESCRIPTION
- Release pipeline only triggers on tags (was triggering on every push to main)
- E2E test uses docker run instead of service container (scratch image healthcheck incompatible with GH Actions service containers)
- binaries, helm, homebrew workflows already tag-only (no change)
- CI stays on push to main + PRs (correct)
- Docs only on website/ path changes (correct)