### PR TITLE
Add .NET example using HttpClient

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ Code examples showing how to use miniblue with different languages and tools.
 | [python/](python/) | Python | Azure SDK for Python with resource groups |
 | [go/](go/) | Go | HTTP client for resource groups and Key Vault |
 | [javascript/](javascript/) | JavaScript | Fetch API for resource groups, Key Vault, Blob Storage |
+| [dotnet/](dotnet/) | C# / .NET 10 for .NET with resource groups, Key Vault, Blob Storage, Cosmos DB |
 | [terraform/](terraform/) | HCL | Full Terraform azurerm provider setup with 5 resource types |
 | [ci/](ci/) | YAML | GitHub Actions workflow with miniblue as a service container |
 
@@ -23,4 +24,5 @@ Then run any example:
     cd examples/python && pip install -r requirements.txt && python example.py
     cd examples/go && go run main.go
     cd examples/javascript && node example.js
+    cd examples/dotnet && dotnet run
     cd examples/terraform && export SSL_CERT_FILE=~/.miniblue/cert.pem && terraform init && terraform apply

--- a/examples/dotnet/.gitignore
+++ b/examples/dotnet/.gitignore
@@ -1,0 +1,17 @@
+# Build output
+bin/
+obj/
+
+# Visual Studio
+.vs/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Rider
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/examples/dotnet/BlobStorageExample.cs
+++ b/examples/dotnet/BlobStorageExample.cs
@@ -1,0 +1,33 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+// -- Blob Storage (HttpClient) ------------------------------------------------
+// Azure.Storage.Blobs v12 interprets path-style URIs as
+// http://{host}/{accountName}/... — "blob" would be parsed as the account name
+// when the service URI is http://localhost:4566/blob/dotnetaccount, which
+// generates wrong blob URLs. miniblue''s blob API uses simple path-based routing,
+// so HttpClient is used directly here.
+sealed class BlobStorageExample
+{
+    private const string BaseUrl = "http://localhost:4566";
+
+    private readonly HttpClient _http = new() { BaseAddress = new Uri(BaseUrl) };
+
+    public async Task RunAsync()
+    {
+        await _http.PutAsync("/blob/dotnetaccount/data", null);
+        Console.WriteLine("\nContainer created: data");
+
+        var payload = """{"database":"postgres://localhost:5432/mydb","env":"local"}""";
+        await _http.PutAsync(
+            "/blob/dotnetaccount/data/config.json",
+            new StringContent(payload, System.Text.Encoding.UTF8, "application/json")
+        );
+        Console.WriteLine("Blob uploaded: config.json");
+
+        var response = await _http.GetFromJsonAsync<JsonElement>(
+            "/blob/dotnetaccount/data/config.json"
+        );
+        Console.WriteLine($"Blob content:  {response}");
+    }
+}

--- a/examples/dotnet/BlobStorageExample.cs
+++ b/examples/dotnet/BlobStorageExample.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 // Azure.Storage.Blobs v12 interprets path-style URIs as
 // http://{host}/{accountName}/... — "blob" would be parsed as the account name
 // when the service URI is http://localhost:4566/blob/dotnetaccount, which
-// generates wrong blob URLs. miniblue''s blob API uses simple path-based routing,
+// generates wrong blob URLs. miniblue's blob API uses simple path-based routing,
 // so HttpClient is used directly here.
 sealed class BlobStorageExample
 {

--- a/examples/dotnet/CosmosDbExample.cs
+++ b/examples/dotnet/CosmosDbExample.cs
@@ -1,0 +1,32 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+// ── Cosmos DB (HttpClient) ────────────────────────────────────────────────────
+// Microsoft.Azure.Cosmos requires a Cosmos-compatible discovery endpoint, which
+// miniblue does not expose. miniblue's Cosmos API uses simple path-based routing,
+// so HttpClient is used directly here.
+sealed class CosmosDbExample
+{
+    private const string BaseUrl = "http://localhost:4566";
+
+    private readonly HttpClient _http = new() { BaseAddress = new Uri(BaseUrl) };
+
+    public async Task RunAsync()
+    {
+        var doc = new
+        {
+            id = "user1",
+            name = "Mo",
+            role = "admin",
+        };
+        await _http.PostAsJsonAsync("/cosmosdb/myaccount/dbs/app/colls/users/docs", doc);
+        Console.WriteLine("\nCosmos doc created: user1");
+
+        var response = await _http.GetFromJsonAsync<JsonElement>(
+            "/cosmosdb/myaccount/dbs/app/colls/users/docs/user1"
+        );
+        Console.WriteLine(
+            $"Cosmos doc: {response.GetProperty("name")} ({response.GetProperty("role")})"
+        );
+    }
+}

--- a/examples/dotnet/KeyVaultExample.cs
+++ b/examples/dotnet/KeyVaultExample.cs
@@ -1,0 +1,27 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+// -- Key Vault (HttpClient) ---------------------------------------------------
+// Azure.Security.KeyVault.Secrets enforces HTTPS at the transport level and
+// cannot be used with an http:// endpoint. miniblue's Key Vault API uses simple
+// path-based routing, so HttpClient is used directly here.
+sealed class KeyVaultExample
+{
+    private const string BaseUrl = "http://localhost:4566";
+
+    private readonly HttpClient _http = new() { BaseAddress = new Uri(BaseUrl) };
+
+    public async Task RunAsync()
+    {
+        await _http.PutAsJsonAsync(
+            "/keyvault/myvault/secrets/db-password",
+            new { value = "super-secret-dotnet-123" }
+        );
+        Console.WriteLine("\nSecret stored: db-password");
+
+        var response = await _http.GetFromJsonAsync<JsonElement>(
+            "/keyvault/myvault/secrets/db-password"
+        );
+        Console.WriteLine($"Secret value:  {response.GetProperty("value")}");
+    }
+}

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -1,0 +1,19 @@
+/*
+ * miniblue .NET example
+ *
+ * Start miniblue: docker run -p 4566:4566 moabukar/miniblue:latest
+ * Run:            dotnet run
+ *
+ * Demonstrates Resource Groups, Key Vault, Blob Storage, and Cosmos DB
+ * using plain HttpClient pointed at http://localhost:4566.
+ */
+
+Console.WriteLine("miniblue .NET example");
+Console.WriteLine("=========================\n");
+
+await new ResourceGroupExample().RunAsync();
+await new KeyVaultExample().RunAsync();
+await new BlobStorageExample().RunAsync();
+await new CosmosDbExample().RunAsync();
+
+Console.WriteLine("\nAll calls went to miniblue!");

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -1,0 +1,62 @@
+# miniblue .NET Example
+
+Demonstrates four Azure services running against **[miniblue](https://github.com/moabukar/miniblue)** — a free, open-source local Azure emulator.
+
+All calls go to `http://localhost:4566` using plain `HttpClient`. No real Azure subscription or credentials required.
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| [.NET SDK](https://dotnet.microsoft.com/download) | 10.0+ |
+| [Docker](https://docs.docker.com/get-docker/) | any recent |
+
+## Start miniblue
+
+```bash
+docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
+```
+
+## Run the example
+
+```bash
+cd examples/dotnet
+dotnet run
+```
+
+Expected output:
+
+```
+miniblue .NET SDK example
+=========================
+
+Resource Group: dotnet-rg (eastus)
+All resource groups:
+  - dotnet-rg
+
+Secret stored: db-password
+Secret value:  super-secret-dotnet-123
+
+Container created: data
+Blob uploaded: config.json
+Blob content:  {"database":"postgres://localhost:5432/mydb","env":"local"}
+
+Cosmos doc created: user1
+Cosmos doc: Mo (admin)
+
+All calls went to miniblue!
+```
+
+## What each file does
+
+| File | Service | Operations |
+|------|---------|------------|
+| `ResourceGroupExample.cs` | ARM Resource Groups | Create, list |
+| `KeyVaultExample.cs` | Key Vault Secrets | Set, get |
+| `BlobStorageExample.cs` | Blob Storage | Create container, upload, download |
+| `CosmosDbExample.cs` | Cosmos DB | Insert document, read document |
+
+## Notes
+
+- The Azure SDK clients for Key Vault (`Azure.Security.KeyVault.Secrets`) and Blob Storage (`Azure.Storage.Blobs`) enforce HTTPS or use incompatible path-style URL parsing for custom endpoints, so this example uses `HttpClient` directly — mirroring the approach in the Python example.
+- miniblue does **not** validate authentication tokens or HMAC signatures.

--- a/examples/dotnet/ResourceGroupExample.cs
+++ b/examples/dotnet/ResourceGroupExample.cs
@@ -1,0 +1,31 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+// ── Resource Groups (HttpClient) ──────────────────────────────────────────────
+// Azure.ResourceManager requires HTTPS for Bearer token auth and performs ARM
+// service discovery that miniblue does not fully support. miniblue''s resource
+// group API uses simple path-based routing, so HttpClient is used directly here.
+sealed class ResourceGroupExample
+{
+    private const string BaseUrl = "http://localhost:4566";
+    private const string SubId = "00000000-0000-0000-0000-000000000000";
+
+    private readonly HttpClient _http = new() { BaseAddress = new Uri(BaseUrl) };
+
+    public async Task RunAsync()
+    {
+        // Create resource group
+        var resp = await _http.PutAsJsonAsync(
+            $"/subscriptions/{SubId}/resourcegroups/dotnet-rg",
+            new { location = "eastus", tags = new { env = "local", sdk = "dotnet" } });
+        var rg = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Console.WriteLine($"Resource Group: {rg.GetProperty("name")} ({rg.GetProperty("location")})");
+
+        // List all resource groups
+        var list = await _http.GetFromJsonAsync<JsonElement>(
+            $"/subscriptions/{SubId}/resourcegroups");
+        Console.WriteLine("All resource groups:");
+        foreach (var item in list.GetProperty("value").EnumerateArray())
+            Console.WriteLine($"  - {item.GetProperty("name")}");
+    }
+}

--- a/examples/dotnet/dotnet.sln
+++ b/examples/dotnet/dotnet.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example", "example.csproj", "{BACE4B62-B1A3-C3DC-6B64-403353019CF3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BACE4B62-B1A3-C3DC-6B64-403353019CF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BACE4B62-B1A3-C3DC-6B64-403353019CF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BACE4B62-B1A3-C3DC-6B64-403353019CF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BACE4B62-B1A3-C3DC-6B64-403353019CF3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CAF31BCE-C90E-42CF-807A-82D81F97C827}
+	EndGlobalSection
+EndGlobal

--- a/examples/dotnet/example.csproj
+++ b/examples/dotnet/example.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## What does this PR do?

 Adds a .NET 10 example under `examples/dotnet/` that demonstrates four miniblue services using plain `HttpClient`.

 ## What's included
 
 ### New files
 | File | Purpose |
 |------|---------|
 | `examples/dotnet/example.csproj` | .NET 10 console project (no external dependencies) |
 | `examples/dotnet/ResourceGroupExample.cs` | Create and list ARM resource groups |
 | `examples/dotnet/KeyVaultExample.cs` | Store and retrieve a Key Vault secret |
 | `examples/dotnet/BlobStorageExample.cs` | Create container, upload and download a blob |
 | `examples/dotnet/CosmosDbExample.cs` | Insert and read a Cosmos DB document |
 
 ## Why HttpClient instead of Azure SDK clients?
 
 The official Azure SDK clients have transport-level restrictions that are
 incompatible with a local HTTP emulator:
 
 - **`Azure.Security.KeyVault.Secrets`** `ChallengeBasedAuthenticationPolicy` throws `InvalidOperationException` for any non-HTTPS endpoint, regardless of options.
 - **`Azure.Storage.Blobs`** path-style URL parsing for localhost treats the first path segment as the account name; with miniblue's `/blob/{account}/…` prefix, "blob" is parsed as the account, generating incorrect request URLs.
 - **`Azure.ResourceManager`** requires HTTPS for Bearer token auth and performs ARM metadata/service-discovery calls that miniblue does not fully support.
 
 Using `HttpClient` directly maps 1-to-1 with miniblue's path-based routing and requires zero NuGet packages.

