### PR TITLE
feat: add Azure Public IP Addresses service emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to miniblue are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Public IP Addresses service (`Microsoft.Network/publicIPAddresses`) with full CRUD, static/dynamic allocation
+
 ## [0.2.0] - 2026-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No Azure account or credentials needed.
 
 ## What it does
 
-21 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
+22 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
 
 | Service | Service | Service |
 |---------|---------|---------|
@@ -53,13 +53,13 @@ No Azure account or credentials needed.
 | DNS Zones | Container Registry | Event Grid |
 | App Configuration | Managed Identity | DB for PostgreSQL |
 | DB for MySQL | Azure SQL Database | Azure Cache for Redis |
-| Container Instances | Subscriptions | Tenants |
+| Container Instances | Public IP Addresses | Subscriptions |
 
 ## How it compares
 
 | | LocalStack (AWS) | MiniStack (AWS) | Azurite (Azure) | miniblue |
 |---|---|---|---|---|
-| Services | 80+ | 36 | 3 (storage only) | **21** |
+| Services | 80+ | 36 | 3 (storage only) | **22** |
 | Docker image | ~1GB | ~200MB | ~300MB | **~8MB** |
 | Startup | ~10s | ~5s | ~3s | **<1s** |
 | Real backends | DynamoDB Local | RDS, S3, SQS | No | **Postgres, Redis, Docker** |

--- a/examples/terraform/publicip.tf
+++ b/examples/terraform/publicip.tf
@@ -1,0 +1,11 @@
+resource "azurerm_public_ip" "example" {
+  name                = "example-public-ip"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  tags = {
+    environment = "dev"
+  }
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moabukar/miniblue/internal/services/keyvault"
 	"github.com/moabukar/miniblue/internal/services/metadata"
 	"github.com/moabukar/miniblue/internal/services/network"
+	"github.com/moabukar/miniblue/internal/services/publicip"
 	"github.com/moabukar/miniblue/internal/services/queue"
 	"github.com/moabukar/miniblue/internal/services/redis"
 	"github.com/moabukar/miniblue/internal/services/resourcegroups"
@@ -169,6 +170,7 @@ func (s *Server) setupRoutes() {
 		{"redis", func() { redis.NewHandler(s.store).Register(s.router) }},
 		{"sqldb", func() { sqldb.NewHandler(s.store).Register(s.router) }},
 		{"dbmysql", func() { dbmysql.NewHandler(s.store).Register(s.router) }},
+		{"publicip", func() { publicip.NewHandler(s.store).Register(s.router) }},
 	}
 	// Always include core infrastructure in service list
 	s.services = []string{"subscriptions", "tenants"}

--- a/internal/services/publicip/handler.go
+++ b/internal/services/publicip/handler.go
@@ -1,0 +1,160 @@
+package publicip
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+var ipCounter uint32
+
+type Handler struct {
+	store *store.Store
+}
+
+func NewHandler(s *store.Store) *Handler {
+	return &Handler{store: s}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses", func(r chi.Router) {
+		r.Get("/", h.List)
+		r.Route("/{publicIpAddressName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdate)
+			r.Get("/", h.Get)
+			r.Delete("/", h.Delete)
+		})
+	})
+}
+
+func (h *Handler) key(sub, rg, name string) string {
+	return "publicip:" + sub + ":" + rg + ":" + name
+}
+
+func nextIP() string {
+	n := atomic.AddUint32(&ipCounter, 1)
+	return fmt.Sprintf("20.0.%d.%d", (n/256)%256, n%256)
+}
+
+func buildResponse(sub, rg, name string, input map[string]interface{}, existingIP string) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/publicIPAddresses/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	allocationMethod, _ := props["publicIPAllocationMethod"].(string)
+	if allocationMethod == "" {
+		allocationMethod = "Static"
+	}
+
+	addressVersion, _ := props["publicIPAddressVersion"].(string)
+	if addressVersion == "" {
+		addressVersion = "IPv4"
+	}
+
+	idleTimeout := 4.0
+	if v, ok := props["idleTimeoutInMinutes"].(float64); ok {
+		idleTimeout = v
+	}
+
+	ipAddress := existingIP
+	if ipAddress == "" {
+		ipAddress = nextIP()
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	sku, _ := input["sku"].(map[string]interface{})
+	if sku == nil {
+		sku = map[string]interface{}{"name": "Standard", "tier": "Regional"}
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.Network/publicIPAddresses",
+		"location": location,
+		"sku":      sku,
+		"properties": map[string]interface{}{
+			"provisioningState":       "Succeeded",
+			"publicIPAllocationMethod": allocationMethod,
+			"publicIPAddressVersion":  addressVersion,
+			"ipAddress":               ipAddress,
+			"idleTimeoutInMinutes":    idleTimeout,
+			"ipConfiguration":         nil,
+			"dnsSettings":             props["dnsSettings"],
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "publicIpAddressName")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	var existingIP string
+	k := h.key(sub, rg, name)
+	if existing, ok := h.store.Get(k); ok {
+		if m, ok := existing.(map[string]interface{}); ok {
+			if p, ok := m["properties"].(map[string]interface{}); ok {
+				existingIP, _ = p["ipAddress"].(string)
+			}
+		}
+	}
+
+	pip := buildResponse(sub, rg, name, input, existingIP)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, pip)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(pip)
+}
+
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "publicIpAddressName")
+
+	v, ok := h.store.Get(h.key(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Network/publicIPAddresses", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "publicIpAddressName")
+
+	if !h.store.Delete(h.key(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Network/publicIPAddresses", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("publicip:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}

--- a/internal/services/publicip/handler.go
+++ b/internal/services/publicip/handler.go
@@ -107,7 +107,8 @@ func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
 
 	var existingIP string
 	k := h.key(sub, rg, name)
-	if existing, ok := h.store.Get(k); ok {
+	existing, exists := h.store.Get(k)
+	if exists {
 		if m, ok := existing.(map[string]interface{}); ok {
 			if p, ok := m["properties"].(map[string]interface{}); ok {
 				existingIP, _ = p["ipAddress"].(string)
@@ -116,7 +117,6 @@ func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pip := buildResponse(sub, rg, name, input, existingIP)
-	_, exists := h.store.Get(k)
 	h.store.Set(k, pip)
 
 	if exists {

--- a/tests/publicip_test.go
+++ b/tests/publicip_test.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestPublicIPLifecycle(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses"
+	av := "?api-version=2023-09-01"
+
+	// Create Public IP
+	resp := doRequest(t, "PUT", base+"/pip1"+av,
+		`{"location":"eastus","sku":{"name":"Standard","tier":"Regional"},"properties":{"publicIPAllocationMethod":"Static","publicIPAddressVersion":"IPv4"}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	if m["name"] != "pip1" {
+		t.Fatalf("expected name=pip1, got %v", m["name"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded")
+	}
+	if props["ipAddress"] == nil || props["ipAddress"] == "" {
+		t.Fatalf("expected ipAddress to be set")
+	}
+	resp.Body.Close()
+
+	// Get Public IP
+	resp = doRequest(t, "GET", base+"/pip1"+av, "")
+	expectStatus(t, resp, 200)
+	resp.Body.Close()
+
+	// List Public IPs
+	resp = doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	items := list["value"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 public IP, got %d", len(items))
+	}
+	resp.Body.Close()
+
+	// Update Public IP (PUT again)
+	resp = doRequest(t, "PUT", base+"/pip1"+av,
+		`{"location":"westus","sku":{"name":"Standard","tier":"Regional"},"properties":{"publicIPAllocationMethod":"Dynamic"}}`)
+	expectStatus(t, resp, 200)
+	resp.Body.Close()
+
+	// Delete Public IP
+	resp = doRequest(t, "DELETE", base+"/pip1"+av, "")
+	expectStatus(t, resp, 202)
+	resp.Body.Close()
+
+	// Get deleted
+	resp = doRequest(t, "GET", base+"/pip1"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}

--- a/tests/publicip_test.go
+++ b/tests/publicip_test.go
@@ -15,38 +15,63 @@ func TestPublicIPLifecycle(t *testing.T) {
 		`{"location":"eastus","sku":{"name":"Standard","tier":"Regional"},"properties":{"publicIPAllocationMethod":"Static","publicIPAddressVersion":"IPv4"}}`)
 	expectStatus(t, resp, 201)
 	m := decodeJSON(t, resp)
+	resp.Body.Close()
 	if m["name"] != "pip1" {
 		t.Fatalf("expected name=pip1, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.Network/publicIPAddresses" {
+		t.Fatalf("expected correct type, got %v", m["type"])
 	}
 	props := m["properties"].(map[string]interface{})
 	if props["provisioningState"] != "Succeeded" {
 		t.Fatalf("expected provisioningState=Succeeded")
 	}
-	if props["ipAddress"] == nil || props["ipAddress"] == "" {
+	if props["publicIPAllocationMethod"] != "Static" {
+		t.Fatalf("expected allocationMethod=Static, got %v", props["publicIPAllocationMethod"])
+	}
+	if props["publicIPAddressVersion"] != "IPv4" {
+		t.Fatalf("expected version=IPv4, got %v", props["publicIPAddressVersion"])
+	}
+	originalIP := props["ipAddress"].(string)
+	if originalIP == "" {
 		t.Fatalf("expected ipAddress to be set")
 	}
-	resp.Body.Close()
 
 	// Get Public IP
 	resp = doRequest(t, "GET", base+"/pip1"+av, "")
 	expectStatus(t, resp, 200)
+	got := decodeJSON(t, resp)
 	resp.Body.Close()
+	if got["name"] != "pip1" {
+		t.Fatalf("GET: expected name=pip1, got %v", got["name"])
+	}
 
 	// List Public IPs
 	resp = doRequest(t, "GET", base+av, "")
 	expectStatus(t, resp, 200)
 	list := decodeJSON(t, resp)
+	resp.Body.Close()
 	items := list["value"].([]interface{})
 	if len(items) != 1 {
 		t.Fatalf("expected 1 public IP, got %d", len(items))
 	}
-	resp.Body.Close()
 
-	// Update Public IP (PUT again)
+	// Update Public IP (PUT again) - IP should be preserved
 	resp = doRequest(t, "PUT", base+"/pip1"+av,
 		`{"location":"westus","sku":{"name":"Standard","tier":"Regional"},"properties":{"publicIPAllocationMethod":"Dynamic"}}`)
 	expectStatus(t, resp, 200)
+	updated := decodeJSON(t, resp)
 	resp.Body.Close()
+	updatedProps := updated["properties"].(map[string]interface{})
+	if updatedProps["ipAddress"] != originalIP {
+		t.Fatalf("expected IP preserved on update: want %s, got %v", originalIP, updatedProps["ipAddress"])
+	}
+	if updatedProps["publicIPAllocationMethod"] != "Dynamic" {
+		t.Fatalf("expected allocationMethod=Dynamic after update, got %v", updatedProps["publicIPAllocationMethod"])
+	}
+	if updated["location"] != "westus" {
+		t.Fatalf("expected location=westus after update, got %v", updated["location"])
+	}
 
 	// Delete Public IP
 	resp = doRequest(t, "DELETE", base+"/pip1"+av, "")
@@ -57,4 +82,106 @@ func TestPublicIPLifecycle(t *testing.T) {
 	resp = doRequest(t, "GET", base+"/pip1"+av, "")
 	expectStatus(t, resp, 404)
 	resp.Body.Close()
+}
+
+func TestPublicIPNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	e := decodeError(t, resp)
+	resp.Body.Close()
+	if e.Error.Code != "ResourceNotFound" {
+		t.Fatalf("expected ResourceNotFound, got %s", e.Error.Code)
+	}
+}
+
+func TestPublicIPDeleteNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "DELETE", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}
+
+func TestPublicIPEmptyList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	items := list["value"].([]interface{})
+	if len(items) != 0 {
+		t.Fatalf("expected 0 public IPs, got %d", len(items))
+	}
+}
+
+func TestPublicIPDefaults(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses"
+	av := "?api-version=2023-09-01"
+
+	// Create with minimal body - should get defaults
+	resp := doRequest(t, "PUT", base+"/pip-defaults"+av, `{}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	if m["location"] != "eastus" {
+		t.Fatalf("expected default location=eastus, got %v", m["location"])
+	}
+	sku := m["sku"].(map[string]interface{})
+	if sku["name"] != "Standard" {
+		t.Fatalf("expected default sku=Standard, got %v", sku["name"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["publicIPAllocationMethod"] != "Static" {
+		t.Fatalf("expected default allocationMethod=Static, got %v", props["publicIPAllocationMethod"])
+	}
+	if props["publicIPAddressVersion"] != "IPv4" {
+		t.Fatalf("expected default version=IPv4, got %v", props["publicIPAddressVersion"])
+	}
+
+	doRequest(t, "DELETE", base+"/pip-defaults"+av, "").Body.Close()
+}
+
+func TestPublicIPMultipleResources(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/pip-a"+av, `{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/pip-b"+av, `{"location":"westus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/pip-c"+av, `{"location":"northeurope"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	items := list["value"].([]interface{})
+	if len(items) != 3 {
+		t.Fatalf("expected 3 public IPs, got %d", len(items))
+	}
+
+	// Delete one and verify count
+	doRequest(t, "DELETE", base+"/pip-b"+av, "").Body.Close()
+	resp = doRequest(t, "GET", base+av, "")
+	list = decodeJSON(t, resp)
+	resp.Body.Close()
+	items = list["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 public IPs after delete, got %d", len(items))
+	}
 }

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -130,7 +130,8 @@ curl http://localhost:4566/health
   "services": [
     "subscriptions", "tenants", "resourcegroups", "blob", "table",
     "queue", "keyvault", "cosmosdb", "servicebus", "functions",
-    "network", "dns", "acr", "eventgrid", "appconfig", "identity"
+    "network", "dns", "acr", "eventgrid", "appconfig", "identity",
+    "dbpostgres", "redis", "sqldb", "dbmysql", "publicip"
   ],
   "status": "running",
   "version": "0.2.5"

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -16,7 +16,7 @@ Azure developers have to juggle 5+ separate emulators (Azurite, Cosmos DB Emulat
 docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
 ```
 
-That's it. 21 Azure services are now running locally.
+That's it. 22 Azure services are now running locally.
 
 ## What's included
 
@@ -41,6 +41,7 @@ That's it. 21 Azure services are now running locally.
 | Azure SQL Database | Server + database management |
 | Azure Cache for Redis | Cache management + key listing |
 | Container Instances | Container group lifecycle |
+| Public IP Addresses | Static/dynamic IP allocation |
 
 ## Works with your tools
 

--- a/website/docs/services/overview.md
+++ b/website/docs/services/overview.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-miniblue emulates 21 Azure services on a single port. All services use in-memory storage and require no authentication.
+miniblue emulates 22 Azure services on a single port. All services use in-memory storage and require no authentication.
 
 ## Service status
 
@@ -25,6 +25,7 @@ miniblue emulates 21 Azure services on a single port. All services use in-memory
 | [Azure SQL Database](database-sql.md) | `Microsoft.Sql` | Done | Yes | -- |
 | [Azure Cache for Redis](redis.md) | `Microsoft.Cache` | Done | Yes | -- |
 | [Container Instances](container-instances.md) | `Microsoft.ContainerInstance` | Done | Yes | -- |
+| Public IP Addresses | `Microsoft.Network` | Done | Yes | -- |
 
 ### What "ARM API" and "Data Plane" mean
 
@@ -42,6 +43,7 @@ The following resources work with `hashicorp/azurerm` provider v3.x:
 | `azurerm_subnet` | Virtual Networks |
 | `azurerm_dns_zone` | DNS Zones |
 | `azurerm_container_registry` | Container Registry |
+| `azurerm_public_ip` | Public IP Addresses |
 
 See the [Terraform guide](../guides/terraform.md) for a full working example.
 

--- a/website/docs/services/parity.md
+++ b/website/docs/services/parity.md
@@ -25,6 +25,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Azure SQL Database | Stub | Stub | Stub | Stub | - | ARM only, no real SQL Server |
 | Azure Cache for Redis | Full | Full | Full | Full | - | Real connectivity check via REDIS_URL |
 | Container Instances | Full | Full | Full | Full | - | Real Docker containers when available |
+| Public IP Addresses | Full | Full | Full | Full | - | Static/dynamic allocation, auto-generated IPs |
 | Subscriptions | Full | Full | - | - | - | Mock subscription |
 | Tenants | - | - | Full | - | - | Mock tenant |
 | Providers | Full | Full | Full | - | - | Registration always succeeds |
@@ -52,7 +53,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Instance discovery | Full | Authority validation (internal) |
 | Managed Identity (IMDS) | Full | Token endpoint for workload identity |
 | Cloud metadata | Full | Terraform provider metadata |
-| /health | Full | 21 services listed |
+| /health | Full | 22 services listed |
 | /metrics | Full | Uptime, request count, error rate |
 
 ## Not Implemented


### PR DESCRIPTION
## Summary
- Adds `Microsoft.Network/publicIPAddresses` ARM service emulator with full CRUD operations
- Supports Static/Dynamic allocation methods, SKU configuration, and auto-generated mock IP addresses
- Registered as `publicip` service in the server (filterable via `SERVICES` env var)

## Test plan
- [x] `TestPublicIPLifecycle` — create, get, list, update, delete, and 404 on deleted resource
- [x] All existing tests continue to pass