### PR TITLE
feat: add Azure Network Security Groups service emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 
 ### Added
 - Public IP Addresses service (`Microsoft.Network/publicIPAddresses`) with full CRUD, static/dynamic allocation
+- Network Security Groups service (`Microsoft.Network/networkSecurityGroups`) with security rules and cascade delete
 
 ## [0.2.0] - 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No Azure account or credentials needed.
 
 ## What it does
 
-22 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
+23 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
 
 | Service | Service | Service |
 |---------|---------|---------|
@@ -53,13 +53,13 @@ No Azure account or credentials needed.
 | DNS Zones | Container Registry | Event Grid |
 | App Configuration | Managed Identity | DB for PostgreSQL |
 | DB for MySQL | Azure SQL Database | Azure Cache for Redis |
-| Container Instances | Public IP Addresses | Subscriptions |
+| Container Instances | Public IP Addresses | Network Security Groups |
 
 ## How it compares
 
 | | LocalStack (AWS) | MiniStack (AWS) | Azurite (Azure) | miniblue |
 |---|---|---|---|---|
-| Services | 80+ | 36 | 3 (storage only) | **22** |
+| Services | 80+ | 36 | 3 (storage only) | **23** |
 | Docker image | ~1GB | ~200MB | ~300MB | **~8MB** |
 | Startup | ~10s | ~5s | ~3s | **<1s** |
 | Real backends | DynamoDB Local | RDS, S3, SQS | No | **Postgres, Redis, Docker** |

--- a/examples/terraform/nsg.tf
+++ b/examples/terraform/nsg.tf
@@ -1,0 +1,46 @@
+resource "azurerm_network_security_group" "example" {
+  name                = "example-nsg"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  security_rule {
+    name                       = "allow-http"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-https"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-ssh"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "10.0.0.0/8"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "example" {
+  subnet_id                 = azurerm_subnet.example.id
+  network_security_group_id = azurerm_network_security_group.example.id
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moabukar/miniblue/internal/services/keyvault"
 	"github.com/moabukar/miniblue/internal/services/metadata"
 	"github.com/moabukar/miniblue/internal/services/network"
+	"github.com/moabukar/miniblue/internal/services/nsg"
 	"github.com/moabukar/miniblue/internal/services/publicip"
 	"github.com/moabukar/miniblue/internal/services/queue"
 	"github.com/moabukar/miniblue/internal/services/redis"
@@ -171,6 +172,7 @@ func (s *Server) setupRoutes() {
 		{"sqldb", func() { sqldb.NewHandler(s.store).Register(s.router) }},
 		{"dbmysql", func() { dbmysql.NewHandler(s.store).Register(s.router) }},
 		{"publicip", func() { publicip.NewHandler(s.store).Register(s.router) }},
+		{"nsg", func() { nsg.NewHandler(s.store).Register(s.router) }},
 	}
 	// Always include core infrastructure in service list
 	s.services = []string{"subscriptions", "tenants"}

--- a/internal/services/nsg/handler.go
+++ b/internal/services/nsg/handler.go
@@ -1,0 +1,327 @@
+package nsg
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/moabukar/miniblue/internal/azerr"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+type Handler struct {
+	store *store.Store
+}
+
+func NewHandler(s *store.Store) *Handler {
+	return &Handler{store: s}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups", func(r chi.Router) {
+		r.Get("/", h.ListNSGs)
+		r.Route("/{nsgName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdate)
+			r.Get("/", h.Get)
+			r.Delete("/", h.Delete)
+			r.Route("/securityRules", func(r chi.Router) {
+				r.Get("/", h.ListRules)
+				r.Route("/{ruleName}", func(r chi.Router) {
+					r.Put("/", h.CreateOrUpdateRule)
+					r.Get("/", h.GetRule)
+					r.Delete("/", h.DeleteRule)
+				})
+			})
+		})
+	})
+}
+
+func (h *Handler) nsgKey(sub, rg, name string) string {
+	return "nsg:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) ruleKey(sub, rg, nsg, rule string) string {
+	return "nsgrule:" + sub + ":" + rg + ":" + nsg + ":" + rule
+}
+
+func defaultSecurityRules() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"name": "AllowVnetInBound",
+			"properties": map[string]interface{}{
+				"provisioningState":      "Succeeded",
+				"priority":               float64(65000),
+				"direction":              "Inbound",
+				"access":                 "Allow",
+				"protocol":               "*",
+				"sourceAddressPrefix":    "VirtualNetwork",
+				"destinationAddressPrefix": "VirtualNetwork",
+				"sourcePortRange":        "*",
+				"destinationPortRange":   "*",
+			},
+		},
+		map[string]interface{}{
+			"name": "AllowAzureLoadBalancerInBound",
+			"properties": map[string]interface{}{
+				"provisioningState":      "Succeeded",
+				"priority":               float64(65001),
+				"direction":              "Inbound",
+				"access":                 "Allow",
+				"protocol":               "*",
+				"sourceAddressPrefix":    "AzureLoadBalancer",
+				"destinationAddressPrefix": "*",
+				"sourcePortRange":        "*",
+				"destinationPortRange":   "*",
+			},
+		},
+		map[string]interface{}{
+			"name": "DenyAllInBound",
+			"properties": map[string]interface{}{
+				"provisioningState":      "Succeeded",
+				"priority":               float64(65500),
+				"direction":              "Inbound",
+				"access":                 "Deny",
+				"protocol":               "*",
+				"sourceAddressPrefix":    "*",
+				"destinationAddressPrefix": "*",
+				"sourcePortRange":        "*",
+				"destinationPortRange":   "*",
+			},
+		},
+		map[string]interface{}{
+			"name": "AllowVnetOutBound",
+			"properties": map[string]interface{}{
+				"provisioningState":      "Succeeded",
+				"priority":               float64(65000),
+				"direction":              "Outbound",
+				"access":                 "Allow",
+				"protocol":               "*",
+				"sourceAddressPrefix":    "VirtualNetwork",
+				"destinationAddressPrefix": "VirtualNetwork",
+				"sourcePortRange":        "*",
+				"destinationPortRange":   "*",
+			},
+		},
+		map[string]interface{}{
+			"name": "AllowInternetOutBound",
+			"properties": map[string]interface{}{
+				"provisioningState":      "Succeeded",
+				"priority":               float64(65001),
+				"direction":              "Outbound",
+				"access":                 "Allow",
+				"protocol":               "*",
+				"sourceAddressPrefix":    "*",
+				"destinationAddressPrefix": "Internet",
+				"sourcePortRange":        "*",
+				"destinationPortRange":   "*",
+			},
+		},
+		map[string]interface{}{
+			"name": "DenyAllOutBound",
+			"properties": map[string]interface{}{
+				"provisioningState":      "Succeeded",
+				"priority":               float64(65500),
+				"direction":              "Outbound",
+				"access":                 "Deny",
+				"protocol":               "*",
+				"sourceAddressPrefix":    "*",
+				"destinationAddressPrefix": "*",
+				"sourcePortRange":        "*",
+				"destinationPortRange":   "*",
+			},
+		},
+	}
+}
+
+func buildNSGResponse(sub, rg, name string, input map[string]interface{}, securityRules []interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/networkSecurityGroups/" + name
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	if securityRules == nil {
+		securityRules = []interface{}{}
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.Network/networkSecurityGroups",
+		"location": location,
+		"etag":     "W/\"miniblue\"",
+		"properties": map[string]interface{}{
+			"provisioningState":    "Succeeded",
+			"resourceGuid":        uuid.New().String(),
+			"securityRules":       securityRules,
+			"defaultSecurityRules": defaultSecurityRules(),
+			"subnets":             []interface{}{},
+			"networkInterfaces":   []interface{}{},
+		},
+	}
+}
+
+func buildRuleResponse(sub, rg, nsgName, ruleName string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/networkSecurityGroups/" + nsgName + "/securityRules/" + ruleName
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	ruleProps := map[string]interface{}{
+		"provisioningState": "Succeeded",
+	}
+	for _, field := range []string{
+		"priority", "direction", "access", "protocol",
+		"sourcePortRange", "destinationPortRange",
+		"sourceAddressPrefix", "destinationAddressPrefix",
+		"sourcePortRanges", "destinationPortRanges",
+		"sourceAddressPrefixes", "destinationAddressPrefixes",
+		"description",
+	} {
+		if v, ok := props[field]; ok {
+			ruleProps[field] = v
+		}
+	}
+
+	return map[string]interface{}{
+		"id":         id,
+		"name":       ruleName,
+		"type":       "Microsoft.Network/networkSecurityGroups/securityRules",
+		"properties": ruleProps,
+	}
+}
+
+func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "nsgName")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	k := h.nsgKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+
+	rules := h.store.ListByPrefix(h.ruleKey(sub, rg, name, ""))
+	nsgResp := buildNSGResponse(sub, rg, name, input, rules)
+	h.store.Set(k, nsgResp)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(nsgResp)
+}
+
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "nsgName")
+
+	v, ok := h.store.Get(h.nsgKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Network/networkSecurityGroups", name)
+		return
+	}
+
+	if nsg, ok := v.(map[string]interface{}); ok {
+		ruleItems := h.store.ListByPrefix(h.ruleKey(sub, rg, name, ""))
+		if props, ok := nsg["properties"].(map[string]interface{}); ok {
+			if len(ruleItems) > 0 {
+				props["securityRules"] = ruleItems
+			} else {
+				props["securityRules"] = []interface{}{}
+			}
+		}
+		json.NewEncoder(w).Encode(nsg)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "nsgName")
+
+	if !h.store.Delete(h.nsgKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Network/networkSecurityGroups", name)
+		return
+	}
+	h.store.DeleteByPrefix(h.ruleKey(sub, rg, name, ""))
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListNSGs(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("nsg:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+func (h *Handler) CreateOrUpdateRule(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	nsgName := chi.URLParam(r, "nsgName")
+	ruleName := chi.URLParam(r, "ruleName")
+
+	if !h.store.Exists(h.nsgKey(sub, rg, nsgName)) {
+		azerr.NotFound(w, "Microsoft.Network/networkSecurityGroups", nsgName)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	rule := buildRuleResponse(sub, rg, nsgName, ruleName, input)
+	k := h.ruleKey(sub, rg, nsgName, ruleName)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, rule)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(rule)
+}
+
+func (h *Handler) GetRule(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	nsgName := chi.URLParam(r, "nsgName")
+	ruleName := chi.URLParam(r, "ruleName")
+
+	v, ok := h.store.Get(h.ruleKey(sub, rg, nsgName, ruleName))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Network/networkSecurityGroups/securityRules", ruleName)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteRule(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	nsgName := chi.URLParam(r, "nsgName")
+	ruleName := chi.URLParam(r, "ruleName")
+
+	if !h.store.Delete(h.ruleKey(sub, rg, nsgName, ruleName)) {
+		azerr.NotFound(w, "Microsoft.Network/networkSecurityGroups/securityRules", ruleName)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) ListRules(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	nsgName := chi.URLParam(r, "nsgName")
+	items := h.store.ListByPrefix(h.ruleKey(sub, rg, nsgName, ""))
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}

--- a/tests/nsg_test.go
+++ b/tests/nsg_test.go
@@ -11,51 +11,98 @@ func TestNSGLifecycle(t *testing.T) {
 	av := "?api-version=2023-09-01"
 
 	// Create NSG
-	resp := doRequest(t, "PUT", base+"/nsg1"+av,
-		`{"location":"eastus"}`)
+	resp := doRequest(t, "PUT", base+"/nsg1"+av, `{"location":"eastus"}`)
 	expectStatus(t, resp, 201)
 	m := decodeJSON(t, resp)
+	resp.Body.Close()
 	if m["name"] != "nsg1" {
 		t.Fatalf("expected name=nsg1, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.Network/networkSecurityGroups" {
+		t.Fatalf("expected correct type, got %v", m["type"])
 	}
 	props := m["properties"].(map[string]interface{})
 	if props["provisioningState"] != "Succeeded" {
 		t.Fatalf("expected provisioningState=Succeeded")
 	}
 	defaultRules := props["defaultSecurityRules"].([]interface{})
-	if len(defaultRules) < 3 {
-		t.Fatalf("expected at least 3 default security rules, got %d", len(defaultRules))
+	if len(defaultRules) != 6 {
+		t.Fatalf("expected 6 default security rules, got %d", len(defaultRules))
 	}
-	resp.Body.Close()
+	secRules := props["securityRules"].([]interface{})
+	if len(secRules) != 0 {
+		t.Fatalf("expected 0 security rules on fresh NSG, got %d", len(secRules))
+	}
 
 	// Get NSG
 	resp = doRequest(t, "GET", base+"/nsg1"+av, "")
 	expectStatus(t, resp, 200)
+	got := decodeJSON(t, resp)
 	resp.Body.Close()
+	if got["name"] != "nsg1" {
+		t.Fatalf("GET: expected name=nsg1, got %v", got["name"])
+	}
 
 	// Create security rule
 	resp = doRequest(t, "PUT", base+"/nsg1/securityRules/allow-http"+av,
 		`{"properties":{"priority":100,"direction":"Inbound","access":"Allow","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*"}}`)
 	expectStatus(t, resp, 201)
 	rule := decodeJSON(t, resp)
+	resp.Body.Close()
 	if rule["name"] != "allow-http" {
 		t.Fatalf("expected rule name=allow-http, got %v", rule["name"])
+	}
+	if rule["type"] != "Microsoft.Network/networkSecurityGroups/securityRules" {
+		t.Fatalf("expected correct rule type, got %v", rule["type"])
 	}
 	ruleProps := rule["properties"].(map[string]interface{})
 	if ruleProps["priority"] != float64(100) {
 		t.Fatalf("expected priority=100, got %v", ruleProps["priority"])
 	}
+	if ruleProps["direction"] != "Inbound" {
+		t.Fatalf("expected direction=Inbound, got %v", ruleProps["direction"])
+	}
+	if ruleProps["access"] != "Allow" {
+		t.Fatalf("expected access=Allow, got %v", ruleProps["access"])
+	}
+	if ruleProps["protocol"] != "Tcp" {
+		t.Fatalf("expected protocol=Tcp, got %v", ruleProps["protocol"])
+	}
+
+	// Update the rule (PUT again)
+	resp = doRequest(t, "PUT", base+"/nsg1/securityRules/allow-http"+av,
+		`{"properties":{"priority":150,"direction":"Inbound","access":"Allow","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"8080","sourceAddressPrefix":"10.0.0.0/8","destinationAddressPrefix":"*"}}`)
+	expectStatus(t, resp, 200)
+	updatedRule := decodeJSON(t, resp)
 	resp.Body.Close()
+	updatedRuleProps := updatedRule["properties"].(map[string]interface{})
+	if updatedRuleProps["priority"] != float64(150) {
+		t.Fatalf("expected updated priority=150, got %v", updatedRuleProps["priority"])
+	}
+	if updatedRuleProps["destinationPortRange"] != "8080" {
+		t.Fatalf("expected updated port=8080, got %v", updatedRuleProps["destinationPortRange"])
+	}
 
 	// List security rules
 	resp = doRequest(t, "GET", base+"/nsg1/securityRules"+av, "")
 	expectStatus(t, resp, 200)
 	list := decodeJSON(t, resp)
+	resp.Body.Close()
 	rules := list["value"].([]interface{})
 	if len(rules) != 1 {
 		t.Fatalf("expected 1 security rule, got %d", len(rules))
 	}
+
+	// Get NSG again - should show security rules populated
+	resp = doRequest(t, "GET", base+"/nsg1"+av, "")
+	expectStatus(t, resp, 200)
+	nsgWithRules := decodeJSON(t, resp)
 	resp.Body.Close()
+	nsgProps := nsgWithRules["properties"].(map[string]interface{})
+	nsgSecRules := nsgProps["securityRules"].([]interface{})
+	if len(nsgSecRules) != 1 {
+		t.Fatalf("expected NSG to show 1 security rule, got %d", len(nsgSecRules))
+	}
 
 	// Delete security rule
 	resp = doRequest(t, "DELETE", base+"/nsg1/securityRules/allow-http"+av, "")
@@ -84,20 +131,37 @@ func TestNSGCascadeDeleteRules(t *testing.T) {
 	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
 	av := "?api-version=2023-09-01"
 
-	// Create NSG with a rule
+	// Create NSG with multiple rules
 	doRequest(t, "PUT", base+"/nsg2"+av, `{"location":"eastus"}`).Body.Close()
 	doRequest(t, "PUT", base+"/nsg2/securityRules/rule1"+av,
+		`{"properties":{"priority":100,"direction":"Inbound","access":"Allow","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*"}}`).Body.Close()
+	doRequest(t, "PUT", base+"/nsg2/securityRules/rule2"+av,
 		`{"properties":{"priority":200,"direction":"Inbound","access":"Deny","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*"}}`).Body.Close()
 
-	// Delete NSG should cascade delete rules
-	doRequest(t, "DELETE", base+"/nsg2"+av, "").Body.Close()
+	// Verify 2 rules exist
+	resp := doRequest(t, "GET", base+"/nsg2/securityRules"+av, "")
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	rules := list["value"].([]interface{})
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules before cascade delete, got %d", len(rules))
+	}
 
-	resp := doRequest(t, "GET", base+"/nsg2/securityRules/rule1"+av, "")
+	// Delete NSG should cascade delete all rules
+	resp = doRequest(t, "DELETE", base+"/nsg2"+av, "")
+	expectStatus(t, resp, 202)
+	resp.Body.Close()
+
+	resp = doRequest(t, "GET", base+"/nsg2/securityRules/rule1"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+
+	resp = doRequest(t, "GET", base+"/nsg2/securityRules/rule2"+av, "")
 	expectStatus(t, resp, 404)
 	resp.Body.Close()
 }
 
-func TestRuleOnNonexistentNSG(t *testing.T) {
+func TestNSGRuleOnNonexistentNSG(t *testing.T) {
 	ts := setupServer()
 	defer ts.Close()
 	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
@@ -106,5 +170,61 @@ func TestRuleOnNonexistentNSG(t *testing.T) {
 	resp := doRequest(t, "PUT", base+"/nope/securityRules/rule1"+av,
 		`{"properties":{"priority":100,"direction":"Inbound","access":"Allow","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"443","sourceAddressPrefix":"*","destinationAddressPrefix":"*"}}`)
 	expectStatus(t, resp, 404)
+	e := decodeError(t, resp)
 	resp.Body.Close()
+	if e.Error.Code != "ResourceNotFound" {
+		t.Fatalf("expected ResourceNotFound, got %s", e.Error.Code)
+	}
+}
+
+func TestNSGNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+
+	resp = doRequest(t, "DELETE", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}
+
+func TestNSGEmptyList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	items := list["value"].([]interface{})
+	if len(items) != 0 {
+		t.Fatalf("expected 0 NSGs, got %d", len(items))
+	}
+}
+
+func TestNSGUpdateReturns200(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/nsg-upd"+av, `{"location":"eastus"}`)
+	expectStatus(t, resp, 201)
+	resp.Body.Close()
+
+	resp = doRequest(t, "PUT", base+"/nsg-upd"+av, `{"location":"westus"}`)
+	expectStatus(t, resp, 200)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+	if m["location"] != "westus" {
+		t.Fatalf("expected updated location=westus, got %v", m["location"])
+	}
+
+	doRequest(t, "DELETE", base+"/nsg-upd"+av, "").Body.Close()
 }

--- a/tests/nsg_test.go
+++ b/tests/nsg_test.go
@@ -1,0 +1,110 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestNSGLifecycle(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
+	av := "?api-version=2023-09-01"
+
+	// Create NSG
+	resp := doRequest(t, "PUT", base+"/nsg1"+av,
+		`{"location":"eastus"}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	if m["name"] != "nsg1" {
+		t.Fatalf("expected name=nsg1, got %v", m["name"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded")
+	}
+	defaultRules := props["defaultSecurityRules"].([]interface{})
+	if len(defaultRules) < 3 {
+		t.Fatalf("expected at least 3 default security rules, got %d", len(defaultRules))
+	}
+	resp.Body.Close()
+
+	// Get NSG
+	resp = doRequest(t, "GET", base+"/nsg1"+av, "")
+	expectStatus(t, resp, 200)
+	resp.Body.Close()
+
+	// Create security rule
+	resp = doRequest(t, "PUT", base+"/nsg1/securityRules/allow-http"+av,
+		`{"properties":{"priority":100,"direction":"Inbound","access":"Allow","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*"}}`)
+	expectStatus(t, resp, 201)
+	rule := decodeJSON(t, resp)
+	if rule["name"] != "allow-http" {
+		t.Fatalf("expected rule name=allow-http, got %v", rule["name"])
+	}
+	ruleProps := rule["properties"].(map[string]interface{})
+	if ruleProps["priority"] != float64(100) {
+		t.Fatalf("expected priority=100, got %v", ruleProps["priority"])
+	}
+	resp.Body.Close()
+
+	// List security rules
+	resp = doRequest(t, "GET", base+"/nsg1/securityRules"+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	rules := list["value"].([]interface{})
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 security rule, got %d", len(rules))
+	}
+	resp.Body.Close()
+
+	// Delete security rule
+	resp = doRequest(t, "DELETE", base+"/nsg1/securityRules/allow-http"+av, "")
+	expectStatus(t, resp, 202)
+	resp.Body.Close()
+
+	// Verify rule deleted
+	resp = doRequest(t, "GET", base+"/nsg1/securityRules/allow-http"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+
+	// Delete NSG
+	resp = doRequest(t, "DELETE", base+"/nsg1"+av, "")
+	expectStatus(t, resp, 202)
+	resp.Body.Close()
+
+	// Get deleted NSG
+	resp = doRequest(t, "GET", base+"/nsg1"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}
+
+func TestNSGCascadeDeleteRules(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
+	av := "?api-version=2023-09-01"
+
+	// Create NSG with a rule
+	doRequest(t, "PUT", base+"/nsg2"+av, `{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/nsg2/securityRules/rule1"+av,
+		`{"properties":{"priority":200,"direction":"Inbound","access":"Deny","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*"}}`).Body.Close()
+
+	// Delete NSG should cascade delete rules
+	doRequest(t, "DELETE", base+"/nsg2"+av, "").Body.Close()
+
+	resp := doRequest(t, "GET", base+"/nsg2/securityRules/rule1"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}
+
+func TestRuleOnNonexistentNSG(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/nope/securityRules/rule1"+av,
+		`{"properties":{"priority":100,"direction":"Inbound","access":"Allow","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"443","sourceAddressPrefix":"*","destinationAddressPrefix":"*"}}`)
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -131,7 +131,7 @@ curl http://localhost:4566/health
     "subscriptions", "tenants", "resourcegroups", "blob", "table",
     "queue", "keyvault", "cosmosdb", "servicebus", "functions",
     "network", "dns", "acr", "eventgrid", "appconfig", "identity",
-    "dbpostgres", "redis", "sqldb", "dbmysql", "publicip"
+    "dbpostgres", "redis", "sqldb", "dbmysql", "publicip", "nsg"
   ],
   "status": "running",
   "version": "0.2.5"

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -16,7 +16,7 @@ Azure developers have to juggle 5+ separate emulators (Azurite, Cosmos DB Emulat
 docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
 ```
 
-That's it. 22 Azure services are now running locally.
+That's it. 23 Azure services are now running locally.
 
 ## What's included
 
@@ -42,6 +42,7 @@ That's it. 22 Azure services are now running locally.
 | Azure Cache for Redis | Cache management + key listing |
 | Container Instances | Container group lifecycle |
 | Public IP Addresses | Static/dynamic IP allocation |
+| Network Security Groups | NSGs with security rules |
 
 ## Works with your tools
 

--- a/website/docs/services/overview.md
+++ b/website/docs/services/overview.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-miniblue emulates 22 Azure services on a single port. All services use in-memory storage and require no authentication.
+miniblue emulates 23 Azure services on a single port. All services use in-memory storage and require no authentication.
 
 ## Service status
 
@@ -26,6 +26,7 @@ miniblue emulates 22 Azure services on a single port. All services use in-memory
 | [Azure Cache for Redis](redis.md) | `Microsoft.Cache` | Done | Yes | -- |
 | [Container Instances](container-instances.md) | `Microsoft.ContainerInstance` | Done | Yes | -- |
 | Public IP Addresses | `Microsoft.Network` | Done | Yes | -- |
+| Network Security Groups | `Microsoft.Network` | Done | Yes | -- |
 
 ### What "ARM API" and "Data Plane" mean
 
@@ -44,6 +45,8 @@ The following resources work with `hashicorp/azurerm` provider v3.x:
 | `azurerm_dns_zone` | DNS Zones |
 | `azurerm_container_registry` | Container Registry |
 | `azurerm_public_ip` | Public IP Addresses |
+| `azurerm_network_security_group` | Network Security Groups |
+| `azurerm_network_security_rule` | Network Security Groups |
 
 See the [Terraform guide](../guides/terraform.md) for a full working example.
 

--- a/website/docs/services/parity.md
+++ b/website/docs/services/parity.md
@@ -26,6 +26,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Azure Cache for Redis | Full | Full | Full | Full | - | Real connectivity check via REDIS_URL |
 | Container Instances | Full | Full | Full | Full | - | Real Docker containers when available |
 | Public IP Addresses | Full | Full | Full | Full | - | Static/dynamic allocation, auto-generated IPs |
+| Network Security Groups | Full | Full | Full | Full | - | Security rules, default rules, cascade delete |
 | Subscriptions | Full | Full | - | - | - | Mock subscription |
 | Tenants | - | - | Full | - | - | Mock tenant |
 | Providers | Full | Full | Full | - | - | Registration always succeeds |
@@ -53,7 +54,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Instance discovery | Full | Authority validation (internal) |
 | Managed Identity (IMDS) | Full | Token endpoint for workload identity |
 | Cloud metadata | Full | Terraform provider metadata |
-| /health | Full | 22 services listed |
+| /health | Full | 23 services listed |
 | /metrics | Full | Uptime, request count, error rate |
 
 ## Not Implemented


### PR DESCRIPTION
## Summary
- Adds `Microsoft.Network/networkSecurityGroups` ARM service emulator with full CRUD for NSGs and security rules
- Includes 6 default security rules (AllowVnetInBound, AllowAzureLoadBalancerInBound, DenyAllInBound, AllowVnetOutBound, AllowInternetOutBound, DenyAllOutBound)
- Supports cascading delete (deleting an NSG removes all its security rules)
- Registered as `nsg` service in the server (filterable via `SERVICES` env var)

## Test plan
- [x] `TestNSGLifecycle` — create NSG, get, create rule, list rules, delete rule, delete NSG, 404 on deleted
- [x] `TestNSGCascadeDeleteRules` — deleting NSG cascades to child security rules
- [x] `TestRuleOnNonexistentNSG` — creating rule on missing NSG returns 404
- [x] All existing tests continue to pass