### PR TITLE
feat: add Azure Load Balancer service emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 ### Added
 - Public IP Addresses service (`Microsoft.Network/publicIPAddresses`) with full CRUD, static/dynamic allocation
 - Network Security Groups service (`Microsoft.Network/networkSecurityGroups`) with security rules and cascade delete
+- Azure Load Balancer service (`Microsoft.Network/loadBalancers`) with frontend IPs, backend pools, rules and probes
+- Terraform example for load balancer (`examples/terraform/loadbalancer.tf`)
 
 ## [0.2.0] - 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No Azure account or credentials needed.
 
 ## What it does
 
-23 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
+24 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
 
 | Service | Service | Service |
 |---------|---------|---------|
@@ -54,12 +54,13 @@ No Azure account or credentials needed.
 | App Configuration | Managed Identity | DB for PostgreSQL |
 | DB for MySQL | Azure SQL Database | Azure Cache for Redis |
 | Container Instances | Public IP Addresses | Network Security Groups |
+| Load Balancer | Subscriptions | Tenants |
 
 ## How it compares
 
 | | LocalStack (AWS) | MiniStack (AWS) | Azurite (Azure) | miniblue |
 |---|---|---|---|---|
-| Services | 80+ | 36 | 3 (storage only) | **23** |
+| Services | 80+ | 36 | 3 (storage only) | **24** |
 | Docker image | ~1GB | ~200MB | ~300MB | **~8MB** |
 | Startup | ~10s | ~5s | ~3s | **<1s** |
 | Real backends | DynamoDB Local | RDS, S3, SQS | No | **Postgres, Redis, Docker** |

--- a/examples/terraform/loadbalancer.tf
+++ b/examples/terraform/loadbalancer.tf
@@ -1,0 +1,42 @@
+resource "azurerm_public_ip" "lb" {
+  name                = "lb-public-ip"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_lb" "example" {
+  name                = "example-lb"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "frontend"
+    public_ip_address_id = azurerm_public_ip.lb.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "example" {
+  loadbalancer_id = azurerm_lb.example.id
+  name            = "backend-pool"
+}
+
+resource "azurerm_lb_probe" "example" {
+  loadbalancer_id = azurerm_lb.example.id
+  name            = "http-probe"
+  protocol        = "Tcp"
+  port            = 80
+}
+
+resource "azurerm_lb_rule" "example" {
+  loadbalancer_id                = azurerm_lb.example.id
+  name                           = "http-rule"
+  protocol                       = "Tcp"
+  frontend_port                  = 80
+  backend_port                   = 80
+  frontend_ip_configuration_name = "frontend"
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.example.id]
+  probe_id                       = azurerm_lb_probe.example.id
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/moabukar/miniblue/internal/services/functions"
 	"github.com/moabukar/miniblue/internal/services/identity"
 	"github.com/moabukar/miniblue/internal/services/keyvault"
+	"github.com/moabukar/miniblue/internal/services/loadbalancer"
 	"github.com/moabukar/miniblue/internal/services/metadata"
 	"github.com/moabukar/miniblue/internal/services/network"
 	"github.com/moabukar/miniblue/internal/services/nsg"
@@ -173,6 +174,7 @@ func (s *Server) setupRoutes() {
 		{"dbmysql", func() { dbmysql.NewHandler(s.store).Register(s.router) }},
 		{"publicip", func() { publicip.NewHandler(s.store).Register(s.router) }},
 		{"nsg", func() { nsg.NewHandler(s.store).Register(s.router) }},
+		{"loadbalancer", func() { loadbalancer.NewHandler(s.store).Register(s.router) }},
 	}
 	// Always include core infrastructure in service list
 	s.services = []string{"subscriptions", "tenants"}

--- a/internal/services/loadbalancer/handler.go
+++ b/internal/services/loadbalancer/handler.go
@@ -1,0 +1,133 @@
+package loadbalancer
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/moabukar/miniblue/internal/azerr"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+type Handler struct {
+	store *store.Store
+}
+
+func NewHandler(s *store.Store) *Handler {
+	return &Handler{store: s}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers", func(r chi.Router) {
+		r.Get("/", h.List)
+		r.Route("/{loadBalancerName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdate)
+			r.Get("/", h.Get)
+			r.Delete("/", h.Delete)
+		})
+	})
+}
+
+func (h *Handler) key(sub, rg, name string) string {
+	return "lb:" + sub + ":" + rg + ":" + name
+}
+
+func getArray(props map[string]interface{}, field string) []interface{} {
+	if v, ok := props[field].([]interface{}); ok {
+		return v
+	}
+	return []interface{}{}
+}
+
+func buildResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/loadBalancers/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	sku, _ := input["sku"].(map[string]interface{})
+	if sku == nil {
+		sku = map[string]interface{}{"name": "Standard", "tier": "Regional"}
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.Network/loadBalancers",
+		"location": location,
+		"etag":     "W/\"miniblue\"",
+		"sku":      sku,
+		"properties": map[string]interface{}{
+			"provisioningState":        "Succeeded",
+			"resourceGuid":            uuid.New().String(),
+			"frontendIPConfigurations": getArray(props, "frontendIPConfigurations"),
+			"backendAddressPools":      getArray(props, "backendAddressPools"),
+			"loadBalancingRules":       getArray(props, "loadBalancingRules"),
+			"probes":                   getArray(props, "probes"),
+			"inboundNatRules":          getArray(props, "inboundNatRules"),
+			"inboundNatPools":          getArray(props, "inboundNatPools"),
+			"outboundRules":            getArray(props, "outboundRules"),
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "loadBalancerName")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	lb := buildResponse(sub, rg, name, input)
+	k := h.key(sub, rg, name)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, lb)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(lb)
+}
+
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "loadBalancerName")
+
+	v, ok := h.store.Get(h.key(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Network/loadBalancers", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "loadBalancerName")
+
+	if !h.store.Delete(h.key(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Network/loadBalancers", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("lb:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}

--- a/tests/loadbalancer_test.go
+++ b/tests/loadbalancer_test.go
@@ -10,7 +10,7 @@ func TestLoadBalancerLifecycle(t *testing.T) {
 	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
 	av := "?api-version=2023-09-01"
 
-	// Create Load Balancer
+	// Create Load Balancer with full config
 	resp := doRequest(t, "PUT", base+"/lb1"+av, `{
 		"location":"eastus",
 		"sku":{"name":"Standard","tier":"Regional"},
@@ -23,8 +23,19 @@ func TestLoadBalancerLifecycle(t *testing.T) {
 	}`)
 	expectStatus(t, resp, 201)
 	m := decodeJSON(t, resp)
+	resp.Body.Close()
 	if m["name"] != "lb1" {
 		t.Fatalf("expected name=lb1, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.Network/loadBalancers" {
+		t.Fatalf("expected correct type, got %v", m["type"])
+	}
+	if m["location"] != "eastus" {
+		t.Fatalf("expected location=eastus, got %v", m["location"])
+	}
+	sku := m["sku"].(map[string]interface{})
+	if sku["name"] != "Standard" {
+		t.Fatalf("expected sku=Standard, got %v", sku["name"])
 	}
 	props := m["properties"].(map[string]interface{})
 	if props["provisioningState"] != "Succeeded" {
@@ -32,32 +43,43 @@ func TestLoadBalancerLifecycle(t *testing.T) {
 	}
 	frontends := props["frontendIPConfigurations"].([]interface{})
 	if len(frontends) != 1 {
-		t.Fatalf("expected 1 frontend IP config, got %d", len(frontends))
+		t.Fatalf("expected 1 frontend, got %d", len(frontends))
 	}
 	backends := props["backendAddressPools"].([]interface{})
 	if len(backends) != 1 {
 		t.Fatalf("expected 1 backend pool, got %d", len(backends))
 	}
-	resp.Body.Close()
+	probes := props["probes"].([]interface{})
+	if len(probes) != 1 {
+		t.Fatalf("expected 1 probe, got %d", len(probes))
+	}
+	rules := props["loadBalancingRules"].([]interface{})
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 LB rule, got %d", len(rules))
+	}
 
 	// Get Load Balancer
 	resp = doRequest(t, "GET", base+"/lb1"+av, "")
 	expectStatus(t, resp, 200)
+	got := decodeJSON(t, resp)
 	resp.Body.Close()
+	if got["name"] != "lb1" {
+		t.Fatalf("GET: expected name=lb1, got %v", got["name"])
+	}
 
 	// List Load Balancers
 	resp = doRequest(t, "GET", base+av, "")
 	expectStatus(t, resp, 200)
 	list := decodeJSON(t, resp)
+	resp.Body.Close()
 	items := list["value"].([]interface{})
 	if len(items) != 1 {
 		t.Fatalf("expected 1 load balancer, got %d", len(items))
 	}
-	resp.Body.Close()
 
-	// Update Load Balancer
+	// Update Load Balancer - add second frontend, verify 200
 	resp = doRequest(t, "PUT", base+"/lb1"+av, `{
-		"location":"eastus",
+		"location":"westus",
 		"sku":{"name":"Standard","tier":"Regional"},
 		"properties":{
 			"frontendIPConfigurations":[{"name":"frontend1"},{"name":"frontend2"}],
@@ -65,7 +87,16 @@ func TestLoadBalancerLifecycle(t *testing.T) {
 		}
 	}`)
 	expectStatus(t, resp, 200)
+	updated := decodeJSON(t, resp)
 	resp.Body.Close()
+	updatedProps := updated["properties"].(map[string]interface{})
+	updatedFrontends := updatedProps["frontendIPConfigurations"].([]interface{})
+	if len(updatedFrontends) != 2 {
+		t.Fatalf("expected 2 frontends after update, got %d", len(updatedFrontends))
+	}
+	if updated["location"] != "westus" {
+		t.Fatalf("expected location=westus after update, got %v", updated["location"])
+	}
 
 	// Delete Load Balancer
 	resp = doRequest(t, "DELETE", base+"/lb1"+av, "")
@@ -76,4 +107,109 @@ func TestLoadBalancerLifecycle(t *testing.T) {
 	resp = doRequest(t, "GET", base+"/lb1"+av, "")
 	expectStatus(t, resp, 404)
 	resp.Body.Close()
+}
+
+func TestLoadBalancerNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	e := decodeError(t, resp)
+	resp.Body.Close()
+	if e.Error.Code != "ResourceNotFound" {
+		t.Fatalf("expected ResourceNotFound, got %s", e.Error.Code)
+	}
+}
+
+func TestLoadBalancerDeleteNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "DELETE", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}
+
+func TestLoadBalancerEmptyList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	items := list["value"].([]interface{})
+	if len(items) != 0 {
+		t.Fatalf("expected 0 LBs, got %d", len(items))
+	}
+}
+
+func TestLoadBalancerDefaults(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
+	av := "?api-version=2023-09-01"
+
+	// Create with minimal body
+	resp := doRequest(t, "PUT", base+"/lb-minimal"+av, `{}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	if m["location"] != "eastus" {
+		t.Fatalf("expected default location=eastus, got %v", m["location"])
+	}
+	sku := m["sku"].(map[string]interface{})
+	if sku["name"] != "Standard" {
+		t.Fatalf("expected default sku=Standard, got %v", sku["name"])
+	}
+
+	// All property arrays should be empty, not nil
+	props := m["properties"].(map[string]interface{})
+	for _, field := range []string{"frontendIPConfigurations", "backendAddressPools", "loadBalancingRules", "probes", "inboundNatRules", "outboundRules"} {
+		arr, ok := props[field].([]interface{})
+		if !ok {
+			t.Fatalf("expected %s to be an array, got %T", field, props[field])
+		}
+		if len(arr) != 0 {
+			t.Fatalf("expected %s to be empty, got %d items", field, len(arr))
+		}
+	}
+
+	doRequest(t, "DELETE", base+"/lb-minimal"+av, "").Body.Close()
+}
+
+func TestLoadBalancerMultiple(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/lb-a"+av, `{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/lb-b"+av, `{"location":"westus"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+av, "")
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	items := list["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 LBs, got %d", len(items))
+	}
+
+	doRequest(t, "DELETE", base+"/lb-a"+av, "").Body.Close()
+
+	resp = doRequest(t, "GET", base+av, "")
+	list = decodeJSON(t, resp)
+	resp.Body.Close()
+	items = list["value"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 LB after delete, got %d", len(items))
+	}
 }

--- a/tests/loadbalancer_test.go
+++ b/tests/loadbalancer_test.go
@@ -1,0 +1,79 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestLoadBalancerLifecycle(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
+	av := "?api-version=2023-09-01"
+
+	// Create Load Balancer
+	resp := doRequest(t, "PUT", base+"/lb1"+av, `{
+		"location":"eastus",
+		"sku":{"name":"Standard","tier":"Regional"},
+		"properties":{
+			"frontendIPConfigurations":[{"name":"frontend1","properties":{"publicIPAddress":{"id":"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip1"}}}],
+			"backendAddressPools":[{"name":"backend1"}],
+			"probes":[{"name":"probe1","properties":{"protocol":"Tcp","port":80,"intervalInSeconds":15,"numberOfProbes":2}}],
+			"loadBalancingRules":[{"name":"rule1","properties":{"frontendIPConfiguration":{"id":"frontend1"},"backendAddressPool":{"id":"backend1"},"probe":{"id":"probe1"},"protocol":"Tcp","frontendPort":80,"backendPort":80}}]
+		}
+	}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	if m["name"] != "lb1" {
+		t.Fatalf("expected name=lb1, got %v", m["name"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded")
+	}
+	frontends := props["frontendIPConfigurations"].([]interface{})
+	if len(frontends) != 1 {
+		t.Fatalf("expected 1 frontend IP config, got %d", len(frontends))
+	}
+	backends := props["backendAddressPools"].([]interface{})
+	if len(backends) != 1 {
+		t.Fatalf("expected 1 backend pool, got %d", len(backends))
+	}
+	resp.Body.Close()
+
+	// Get Load Balancer
+	resp = doRequest(t, "GET", base+"/lb1"+av, "")
+	expectStatus(t, resp, 200)
+	resp.Body.Close()
+
+	// List Load Balancers
+	resp = doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	items := list["value"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 load balancer, got %d", len(items))
+	}
+	resp.Body.Close()
+
+	// Update Load Balancer
+	resp = doRequest(t, "PUT", base+"/lb1"+av, `{
+		"location":"eastus",
+		"sku":{"name":"Standard","tier":"Regional"},
+		"properties":{
+			"frontendIPConfigurations":[{"name":"frontend1"},{"name":"frontend2"}],
+			"backendAddressPools":[{"name":"backend1"}]
+		}
+	}`)
+	expectStatus(t, resp, 200)
+	resp.Body.Close()
+
+	// Delete Load Balancer
+	resp = doRequest(t, "DELETE", base+"/lb1"+av, "")
+	expectStatus(t, resp, 202)
+	resp.Body.Close()
+
+	// Get deleted
+	resp = doRequest(t, "GET", base+"/lb1"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -131,7 +131,8 @@ curl http://localhost:4566/health
     "subscriptions", "tenants", "resourcegroups", "blob", "table",
     "queue", "keyvault", "cosmosdb", "servicebus", "functions",
     "network", "dns", "acr", "eventgrid", "appconfig", "identity",
-    "dbpostgres", "redis", "sqldb", "dbmysql", "publicip", "nsg"
+    "dbpostgres", "redis", "sqldb", "dbmysql", "publicip", "nsg",
+    "loadbalancer"
   ],
   "status": "running",
   "version": "0.2.5"

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -16,7 +16,7 @@ Azure developers have to juggle 5+ separate emulators (Azurite, Cosmos DB Emulat
 docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
 ```
 
-That's it. 23 Azure services are now running locally.
+That's it. 24 Azure services are now running locally.
 
 ## What's included
 
@@ -43,6 +43,7 @@ That's it. 23 Azure services are now running locally.
 | Container Instances | Container group lifecycle |
 | Public IP Addresses | Static/dynamic IP allocation |
 | Network Security Groups | NSGs with security rules |
+| Load Balancer | Frontend IPs, backend pools, rules, probes |
 
 ## Works with your tools
 

--- a/website/docs/services/overview.md
+++ b/website/docs/services/overview.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-miniblue emulates 23 Azure services on a single port. All services use in-memory storage and require no authentication.
+miniblue emulates 24 Azure services on a single port. All services use in-memory storage and require no authentication.
 
 ## Service status
 
@@ -27,6 +27,7 @@ miniblue emulates 23 Azure services on a single port. All services use in-memory
 | [Container Instances](container-instances.md) | `Microsoft.ContainerInstance` | Done | Yes | -- |
 | Public IP Addresses | `Microsoft.Network` | Done | Yes | -- |
 | Network Security Groups | `Microsoft.Network` | Done | Yes | -- |
+| Load Balancer | `Microsoft.Network` | Done | Yes | -- |
 
 ### What "ARM API" and "Data Plane" mean
 
@@ -47,6 +48,10 @@ The following resources work with `hashicorp/azurerm` provider v3.x:
 | `azurerm_public_ip` | Public IP Addresses |
 | `azurerm_network_security_group` | Network Security Groups |
 | `azurerm_network_security_rule` | Network Security Groups |
+| `azurerm_lb` | Load Balancer |
+| `azurerm_lb_backend_address_pool` | Load Balancer |
+| `azurerm_lb_probe` | Load Balancer |
+| `azurerm_lb_rule` | Load Balancer |
 
 See the [Terraform guide](../guides/terraform.md) for a full working example.
 

--- a/website/docs/services/parity.md
+++ b/website/docs/services/parity.md
@@ -27,6 +27,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Container Instances | Full | Full | Full | Full | - | Real Docker containers when available |
 | Public IP Addresses | Full | Full | Full | Full | - | Static/dynamic allocation, auto-generated IPs |
 | Network Security Groups | Full | Full | Full | Full | - | Security rules, default rules, cascade delete |
+| Load Balancer | Full | Full | Full | Full | - | Frontends, backends, rules, probes, NAT |
 | Subscriptions | Full | Full | - | - | - | Mock subscription |
 | Tenants | - | - | Full | - | - | Mock tenant |
 | Providers | Full | Full | Full | - | - | Registration always succeeds |
@@ -54,7 +55,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Instance discovery | Full | Authority validation (internal) |
 | Managed Identity (IMDS) | Full | Token endpoint for workload identity |
 | Cloud metadata | Full | Terraform provider metadata |
-| /health | Full | 23 services listed |
+| /health | Full | 24 services listed |
 | /metrics | Full | Uptime, request count, error rate |
 
 ## Not Implemented


### PR DESCRIPTION
## Summary
- Adds `Microsoft.Network/loadBalancers` ARM service emulator with full CRUD operations
- Supports Standard/Basic SKU, frontend IP configurations, backend address pools, load balancing rules, probes, inbound NAT rules, and outbound rules
- Includes Terraform example (`examples/terraform/loadbalancer.tf`) with public IP, LB, backend pool, probe, and LB rule
- Registered as `loadbalancer` service (filterable via `SERVICES` env var)

## Test plan
- [x] `TestLoadBalancerLifecycle` — create with full config (frontends, backends, probes, rules), get, list, update, delete, 404 on deleted
- [x] Live tested against running miniblue instance with curl (create, get, list, delete, 404)
- [x] All existing tests continue to pass