### PR TITLE
feat: add Azure Application Gateway service emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow 
 - Network Security Groups service (`Microsoft.Network/networkSecurityGroups`) with security rules and cascade delete
 - Azure Load Balancer service (`Microsoft.Network/loadBalancers`) with frontend IPs, backend pools, rules and probes
 - Terraform example for load balancer (`examples/terraform/loadbalancer.tf`)
+- Application Gateway service (`Microsoft.Network/applicationGateways`) with full L7 config
+- Terraform example for application gateway (`examples/terraform/appgateway.tf`)
 
 ## [0.2.0] - 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No Azure account or credentials needed.
 
 ## What it does
 
-24 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
+25 Azure services emulated behind a single port. Works with Terraform, Pulumi, Azure SDKs, and curl.
 
 | Service | Service | Service |
 |---------|---------|---------|
@@ -54,13 +54,13 @@ No Azure account or credentials needed.
 | App Configuration | Managed Identity | DB for PostgreSQL |
 | DB for MySQL | Azure SQL Database | Azure Cache for Redis |
 | Container Instances | Public IP Addresses | Network Security Groups |
-| Load Balancer | Subscriptions | Tenants |
+| Load Balancer | Application Gateway | Subscriptions |
 
 ## How it compares
 
 | | LocalStack (AWS) | MiniStack (AWS) | Azurite (Azure) | miniblue |
 |---|---|---|---|---|
-| Services | 80+ | 36 | 3 (storage only) | **24** |
+| Services | 80+ | 36 | 3 (storage only) | **25** |
 | Docker image | ~1GB | ~200MB | ~300MB | **~8MB** |
 | Startup | ~10s | ~5s | ~3s | **<1s** |
 | Real backends | DynamoDB Local | RDS, S3, SQS | No | **Postgres, Redis, Docker** |

--- a/examples/terraform/appgateway.tf
+++ b/examples/terraform/appgateway.tf
@@ -1,0 +1,69 @@
+resource "azurerm_public_ip" "appgw" {
+  name                = "appgw-public-ip"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_subnet" "appgw" {
+  name                 = "appgw-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_application_gateway" "example" {
+  name                = "example-appgw"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gateway-ip-config"
+    subnet_id = azurerm_subnet.appgw.id
+  }
+
+  frontend_ip_configuration {
+    name                 = "frontend-ip"
+    public_ip_address_id = azurerm_public_ip.appgw.id
+  }
+
+  frontend_port {
+    name = "http-port"
+    port = 80
+  }
+
+  backend_address_pool {
+    name = "backend-pool"
+  }
+
+  backend_http_settings {
+    name                  = "http-settings"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 30
+  }
+
+  http_listener {
+    name                           = "http-listener"
+    frontend_ip_configuration_name = "frontend-ip"
+    frontend_port_name             = "http-port"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "routing-rule"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "http-listener"
+    backend_address_pool_name  = "backend-pool"
+    backend_http_settings_name = "http-settings"
+  }
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moabukar/miniblue/internal/services/aci"
 	"github.com/moabukar/miniblue/internal/services/acr"
 	"github.com/moabukar/miniblue/internal/services/appconfig"
+	"github.com/moabukar/miniblue/internal/services/appgw"
 	"github.com/moabukar/miniblue/internal/services/auth"
 	"github.com/moabukar/miniblue/internal/services/blob"
 	"github.com/moabukar/miniblue/internal/services/cosmosdb"
@@ -175,6 +176,7 @@ func (s *Server) setupRoutes() {
 		{"publicip", func() { publicip.NewHandler(s.store).Register(s.router) }},
 		{"nsg", func() { nsg.NewHandler(s.store).Register(s.router) }},
 		{"loadbalancer", func() { loadbalancer.NewHandler(s.store).Register(s.router) }},
+		{"appgw", func() { appgw.NewHandler(s.store).Register(s.router) }},
 	}
 	// Always include core infrastructure in service list
 	s.services = []string{"subscriptions", "tenants"}

--- a/internal/services/appgw/handler.go
+++ b/internal/services/appgw/handler.go
@@ -1,0 +1,155 @@
+package appgw
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/moabukar/miniblue/internal/azerr"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+type Handler struct {
+	store *store.Store
+}
+
+func NewHandler(s *store.Store) *Handler {
+	return &Handler{store: s}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways", func(r chi.Router) {
+		r.Get("/", h.List)
+		r.Route("/{applicationGatewayName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdate)
+			r.Get("/", h.Get)
+			r.Delete("/", h.Delete)
+		})
+	})
+}
+
+func (h *Handler) key(sub, rg, name string) string {
+	return "appgw:" + sub + ":" + rg + ":" + name
+}
+
+func getArray(props map[string]interface{}, field string) []interface{} {
+	if v, ok := props[field].([]interface{}); ok {
+		return v
+	}
+	return []interface{}{}
+}
+
+func getMap(props map[string]interface{}, field string) map[string]interface{} {
+	if v, ok := props[field].(map[string]interface{}); ok {
+		return v
+	}
+	return nil
+}
+
+func buildResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/applicationGateways/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	sku := getMap(props, "sku")
+	if sku == nil {
+		sku = map[string]interface{}{
+			"name":     "Standard_v2",
+			"tier":     "Standard_v2",
+			"capacity": float64(2),
+		}
+	}
+
+	result := map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.Network/applicationGateways",
+		"location": location,
+		"etag":     "W/\"miniblue\"",
+		"properties": map[string]interface{}{
+			"provisioningState":            "Succeeded",
+			"resourceGuid":                uuid.New().String(),
+			"operationalState":            "Running",
+			"sku":                          sku,
+			"gatewayIPConfigurations":      getArray(props, "gatewayIPConfigurations"),
+			"sslCertificates":             getArray(props, "sslCertificates"),
+			"trustedRootCertificates":     getArray(props, "trustedRootCertificates"),
+			"frontendIPConfigurations":     getArray(props, "frontendIPConfigurations"),
+			"frontendPorts":                getArray(props, "frontendPorts"),
+			"backendAddressPools":          getArray(props, "backendAddressPools"),
+			"backendHttpSettingsCollection": getArray(props, "backendHttpSettingsCollection"),
+			"httpListeners":                getArray(props, "httpListeners"),
+			"urlPathMaps":                  getArray(props, "urlPathMaps"),
+			"requestRoutingRules":          getArray(props, "requestRoutingRules"),
+			"redirectConfigurations":       getArray(props, "redirectConfigurations"),
+			"probes":                       getArray(props, "probes"),
+			"rewriteRuleSets":             getArray(props, "rewriteRuleSets"),
+			"autoscaleConfiguration":       getMap(props, "autoscaleConfiguration"),
+			"webApplicationFirewallConfiguration": getMap(props, "webApplicationFirewallConfiguration"),
+		},
+	}
+
+	return result
+}
+
+func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "applicationGatewayName")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	gw := buildResponse(sub, rg, name, input)
+	k := h.key(sub, rg, name)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, gw)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(gw)
+}
+
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "applicationGatewayName")
+
+	v, ok := h.store.Get(h.key(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Network/applicationGateways", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "applicationGatewayName")
+
+	if !h.store.Delete(h.key(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Network/applicationGateways", name)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("appgw:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}

--- a/tests/appgw_test.go
+++ b/tests/appgw_test.go
@@ -1,0 +1,144 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestAppGatewayLifecycle(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
+	av := "?api-version=2023-09-01"
+
+	body := `{
+		"location":"eastus",
+		"properties":{
+			"sku":{"name":"Standard_v2","tier":"Standard_v2","capacity":2},
+			"gatewayIPConfigurations":[{"name":"gw-ip","properties":{"subnet":{"id":"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/appgw-subnet"}}}],
+			"frontendIPConfigurations":[{"name":"fe-ip","properties":{"publicIPAddress":{"id":"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgw-pip"}}}],
+			"frontendPorts":[{"name":"port80","properties":{"port":80}},{"name":"port443","properties":{"port":443}}],
+			"backendAddressPools":[{"name":"backend","properties":{"backendAddresses":[{"ipAddress":"10.0.1.10"},{"ipAddress":"10.0.1.11"}]}}],
+			"backendHttpSettingsCollection":[{"name":"http-settings","properties":{"port":80,"protocol":"Http","cookieBasedAffinity":"Disabled","requestTimeout":30}}],
+			"httpListeners":[{"name":"http-listener","properties":{"frontendIPConfiguration":{"id":"fe-ip"},"frontendPort":{"id":"port80"},"protocol":"Http"}}],
+			"requestRoutingRules":[{"name":"rule1","properties":{"ruleType":"Basic","priority":100,"httpListener":{"id":"http-listener"},"backendAddressPool":{"id":"backend"},"backendHttpSettings":{"id":"http-settings"}}}],
+			"probes":[{"name":"health","properties":{"protocol":"Http","host":"localhost","path":"/health","interval":30,"timeout":30,"unhealthyThreshold":3}}]
+		}
+	}`
+
+	// Create Application Gateway
+	resp := doRequest(t, "PUT", base+"/appgw1"+av, body)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	if m["name"] != "appgw1" {
+		t.Fatalf("expected name=appgw1, got %v", m["name"])
+	}
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded")
+	}
+	if props["operationalState"] != "Running" {
+		t.Fatalf("expected operationalState=Running, got %v", props["operationalState"])
+	}
+
+	// Verify sub-configurations passed through
+	sku := props["sku"].(map[string]interface{})
+	if sku["name"] != "Standard_v2" {
+		t.Fatalf("expected sku name=Standard_v2, got %v", sku["name"])
+	}
+	frontends := props["frontendIPConfigurations"].([]interface{})
+	if len(frontends) != 1 {
+		t.Fatalf("expected 1 frontend, got %d", len(frontends))
+	}
+	backends := props["backendAddressPools"].([]interface{})
+	if len(backends) != 1 {
+		t.Fatalf("expected 1 backend pool, got %d", len(backends))
+	}
+	listeners := props["httpListeners"].([]interface{})
+	if len(listeners) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(listeners))
+	}
+	rules := props["requestRoutingRules"].([]interface{})
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 routing rule, got %d", len(rules))
+	}
+	ports := props["frontendPorts"].([]interface{})
+	if len(ports) != 2 {
+		t.Fatalf("expected 2 frontend ports, got %d", len(ports))
+	}
+	probes := props["probes"].([]interface{})
+	if len(probes) != 1 {
+		t.Fatalf("expected 1 probe, got %d", len(probes))
+	}
+	resp.Body.Close()
+
+	// Get Application Gateway
+	resp = doRequest(t, "GET", base+"/appgw1"+av, "")
+	expectStatus(t, resp, 200)
+	resp.Body.Close()
+
+	// List Application Gateways
+	resp = doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	items := list["value"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 app gateway, got %d", len(items))
+	}
+	resp.Body.Close()
+
+	// Update Application Gateway
+	resp = doRequest(t, "PUT", base+"/appgw1"+av, `{
+		"location":"eastus",
+		"properties":{
+			"sku":{"name":"WAF_v2","tier":"WAF_v2","capacity":3},
+			"frontendIPConfigurations":[{"name":"fe-ip"}],
+			"backendAddressPools":[{"name":"backend1"},{"name":"backend2"}]
+		}
+	}`)
+	expectStatus(t, resp, 200)
+	updated := decodeJSON(t, resp)
+	updatedProps := updated["properties"].(map[string]interface{})
+	updatedSku := updatedProps["sku"].(map[string]interface{})
+	if updatedSku["name"] != "WAF_v2" {
+		t.Fatalf("expected updated sku name=WAF_v2, got %v", updatedSku["name"])
+	}
+	updatedBackends := updatedProps["backendAddressPools"].([]interface{})
+	if len(updatedBackends) != 2 {
+		t.Fatalf("expected 2 backend pools after update, got %d", len(updatedBackends))
+	}
+	resp.Body.Close()
+
+	// Delete Application Gateway
+	resp = doRequest(t, "DELETE", base+"/appgw1"+av, "")
+	expectStatus(t, resp, 202)
+	resp.Body.Close()
+
+	// Get deleted
+	resp = doRequest(t, "GET", base+"/appgw1"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}
+
+func TestAppGatewayDefaultSku(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
+	av := "?api-version=2023-09-01"
+
+	// Create with minimal config (no sku specified)
+	resp := doRequest(t, "PUT", base+"/appgw-minimal"+av,
+		`{"location":"westus","properties":{}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	props := m["properties"].(map[string]interface{})
+	sku := props["sku"].(map[string]interface{})
+	if sku["name"] != "Standard_v2" {
+		t.Fatalf("expected default sku=Standard_v2, got %v", sku["name"])
+	}
+	if m["location"] != "westus" {
+		t.Fatalf("expected location=westus, got %v", m["location"])
+	}
+	resp.Body.Close()
+
+	doRequest(t, "DELETE", base+"/appgw-minimal"+av, "").Body.Close()
+}

--- a/tests/appgw_test.go
+++ b/tests/appgw_test.go
@@ -29,8 +29,12 @@ func TestAppGatewayLifecycle(t *testing.T) {
 	resp := doRequest(t, "PUT", base+"/appgw1"+av, body)
 	expectStatus(t, resp, 201)
 	m := decodeJSON(t, resp)
+	resp.Body.Close()
 	if m["name"] != "appgw1" {
 		t.Fatalf("expected name=appgw1, got %v", m["name"])
+	}
+	if m["type"] != "Microsoft.Network/applicationGateways" {
+		t.Fatalf("expected correct type, got %v", m["type"])
 	}
 	props := m["properties"].(map[string]interface{})
 	if props["provisioningState"] != "Succeeded" {
@@ -40,10 +44,12 @@ func TestAppGatewayLifecycle(t *testing.T) {
 		t.Fatalf("expected operationalState=Running, got %v", props["operationalState"])
 	}
 
-	// Verify sub-configurations passed through
 	sku := props["sku"].(map[string]interface{})
 	if sku["name"] != "Standard_v2" {
 		t.Fatalf("expected sku name=Standard_v2, got %v", sku["name"])
+	}
+	if sku["tier"] != "Standard_v2" {
+		t.Fatalf("expected sku tier=Standard_v2, got %v", sku["tier"])
 	}
 	frontends := props["frontendIPConfigurations"].([]interface{})
 	if len(frontends) != 1 {
@@ -69,24 +75,35 @@ func TestAppGatewayLifecycle(t *testing.T) {
 	if len(probes) != 1 {
 		t.Fatalf("expected 1 probe, got %d", len(probes))
 	}
-	resp.Body.Close()
+	gwConfigs := props["gatewayIPConfigurations"].([]interface{})
+	if len(gwConfigs) != 1 {
+		t.Fatalf("expected 1 gateway IP config, got %d", len(gwConfigs))
+	}
+	httpSettings := props["backendHttpSettingsCollection"].([]interface{})
+	if len(httpSettings) != 1 {
+		t.Fatalf("expected 1 backend HTTP settings, got %d", len(httpSettings))
+	}
 
 	// Get Application Gateway
 	resp = doRequest(t, "GET", base+"/appgw1"+av, "")
 	expectStatus(t, resp, 200)
+	got := decodeJSON(t, resp)
 	resp.Body.Close()
+	if got["name"] != "appgw1" {
+		t.Fatalf("GET: expected name=appgw1, got %v", got["name"])
+	}
 
 	// List Application Gateways
 	resp = doRequest(t, "GET", base+av, "")
 	expectStatus(t, resp, 200)
 	list := decodeJSON(t, resp)
+	resp.Body.Close()
 	items := list["value"].([]interface{})
 	if len(items) != 1 {
 		t.Fatalf("expected 1 app gateway, got %d", len(items))
 	}
-	resp.Body.Close()
 
-	// Update Application Gateway
+	// Update Application Gateway - change SKU and add backend pool
 	resp = doRequest(t, "PUT", base+"/appgw1"+av, `{
 		"location":"eastus",
 		"properties":{
@@ -97,6 +114,7 @@ func TestAppGatewayLifecycle(t *testing.T) {
 	}`)
 	expectStatus(t, resp, 200)
 	updated := decodeJSON(t, resp)
+	resp.Body.Close()
 	updatedProps := updated["properties"].(map[string]interface{})
 	updatedSku := updatedProps["sku"].(map[string]interface{})
 	if updatedSku["name"] != "WAF_v2" {
@@ -106,7 +124,6 @@ func TestAppGatewayLifecycle(t *testing.T) {
 	if len(updatedBackends) != 2 {
 		t.Fatalf("expected 2 backend pools after update, got %d", len(updatedBackends))
 	}
-	resp.Body.Close()
 
 	// Delete Application Gateway
 	resp = doRequest(t, "DELETE", base+"/appgw1"+av, "")
@@ -119,26 +136,114 @@ func TestAppGatewayLifecycle(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestAppGatewayNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	e := decodeError(t, resp)
+	resp.Body.Close()
+	if e.Error.Code != "ResourceNotFound" {
+		t.Fatalf("expected ResourceNotFound, got %s", e.Error.Code)
+	}
+}
+
+func TestAppGatewayDeleteNotFound(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "DELETE", base+"/nonexistent"+av, "")
+	expectStatus(t, resp, 404)
+	resp.Body.Close()
+}
+
+func TestAppGatewayEmptyList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "GET", base+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	items := list["value"].([]interface{})
+	if len(items) != 0 {
+		t.Fatalf("expected 0 app gateways, got %d", len(items))
+	}
+}
+
 func TestAppGatewayDefaultSku(t *testing.T) {
 	ts := setupServer()
 	defer ts.Close()
 	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
 	av := "?api-version=2023-09-01"
 
-	// Create with minimal config (no sku specified)
+	// Create with minimal config (no sku)
 	resp := doRequest(t, "PUT", base+"/appgw-minimal"+av,
 		`{"location":"westus","properties":{}}`)
 	expectStatus(t, resp, 201)
 	m := decodeJSON(t, resp)
+	resp.Body.Close()
 	props := m["properties"].(map[string]interface{})
 	sku := props["sku"].(map[string]interface{})
 	if sku["name"] != "Standard_v2" {
 		t.Fatalf("expected default sku=Standard_v2, got %v", sku["name"])
 	}
+	if sku["tier"] != "Standard_v2" {
+		t.Fatalf("expected default tier=Standard_v2, got %v", sku["tier"])
+	}
 	if m["location"] != "westus" {
 		t.Fatalf("expected location=westus, got %v", m["location"])
 	}
-	resp.Body.Close()
+
+	// Verify empty arrays for unconfigured sections
+	for _, field := range []string{
+		"gatewayIPConfigurations", "frontendIPConfigurations", "frontendPorts",
+		"backendAddressPools", "backendHttpSettingsCollection", "httpListeners",
+		"requestRoutingRules", "probes", "sslCertificates",
+	} {
+		arr, ok := props[field].([]interface{})
+		if !ok {
+			t.Fatalf("expected %s to be an array, got %T", field, props[field])
+		}
+		if len(arr) != 0 {
+			t.Fatalf("expected %s to be empty, got %d items", field, len(arr))
+		}
+	}
 
 	doRequest(t, "DELETE", base+"/appgw-minimal"+av, "").Body.Close()
+}
+
+func TestAppGatewayMultiple(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/appgw-a"+av, `{"location":"eastus","properties":{}}`).Body.Close()
+	doRequest(t, "PUT", base+"/appgw-b"+av, `{"location":"westus","properties":{}}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+av, "")
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+	items := list["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 app gateways, got %d", len(items))
+	}
+
+	doRequest(t, "DELETE", base+"/appgw-a"+av, "").Body.Close()
+
+	resp = doRequest(t, "GET", base+av, "")
+	list = decodeJSON(t, resp)
+	resp.Body.Close()
+	items = list["value"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 app gateway after delete, got %d", len(items))
+	}
 }

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -132,7 +132,7 @@ curl http://localhost:4566/health
     "queue", "keyvault", "cosmosdb", "servicebus", "functions",
     "network", "dns", "acr", "eventgrid", "appconfig", "identity",
     "dbpostgres", "redis", "sqldb", "dbmysql", "publicip", "nsg",
-    "loadbalancer"
+    "loadbalancer", "appgw"
   ],
   "status": "running",
   "version": "0.2.5"

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -16,7 +16,7 @@ Azure developers have to juggle 5+ separate emulators (Azurite, Cosmos DB Emulat
 docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
 ```
 
-That's it. 24 Azure services are now running locally.
+That's it. 25 Azure services are now running locally.
 
 ## What's included
 
@@ -44,6 +44,7 @@ That's it. 24 Azure services are now running locally.
 | Public IP Addresses | Static/dynamic IP allocation |
 | Network Security Groups | NSGs with security rules |
 | Load Balancer | Frontend IPs, backend pools, rules, probes |
+| Application Gateway | L7 load balancing, WAF, routing rules |
 
 ## Works with your tools
 

--- a/website/docs/services/overview.md
+++ b/website/docs/services/overview.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-miniblue emulates 24 Azure services on a single port. All services use in-memory storage and require no authentication.
+miniblue emulates 25 Azure services on a single port. All services use in-memory storage and require no authentication.
 
 ## Service status
 
@@ -28,6 +28,7 @@ miniblue emulates 24 Azure services on a single port. All services use in-memory
 | Public IP Addresses | `Microsoft.Network` | Done | Yes | -- |
 | Network Security Groups | `Microsoft.Network` | Done | Yes | -- |
 | Load Balancer | `Microsoft.Network` | Done | Yes | -- |
+| Application Gateway | `Microsoft.Network` | Done | Yes | -- |
 
 ### What "ARM API" and "Data Plane" mean
 
@@ -52,6 +53,7 @@ The following resources work with `hashicorp/azurerm` provider v3.x:
 | `azurerm_lb_backend_address_pool` | Load Balancer |
 | `azurerm_lb_probe` | Load Balancer |
 | `azurerm_lb_rule` | Load Balancer |
+| `azurerm_application_gateway` | Application Gateway |
 
 See the [Terraform guide](../guides/terraform.md) for a full working example.
 

--- a/website/docs/services/parity.md
+++ b/website/docs/services/parity.md
@@ -28,6 +28,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Public IP Addresses | Full | Full | Full | Full | - | Static/dynamic allocation, auto-generated IPs |
 | Network Security Groups | Full | Full | Full | Full | - | Security rules, default rules, cascade delete |
 | Load Balancer | Full | Full | Full | Full | - | Frontends, backends, rules, probes, NAT |
+| Application Gateway | Full | Full | Full | Full | - | SKU, frontends, backends, listeners, rules, probes, WAF |
 | Subscriptions | Full | Full | - | - | - | Mock subscription |
 | Tenants | - | - | Full | - | - | Mock tenant |
 | Providers | Full | Full | Full | - | - | Registration always succeeds |
@@ -55,7 +56,7 @@ What's implemented, stubbed, and unsupported in miniblue compared to real Azure 
 | Instance discovery | Full | Authority validation (internal) |
 | Managed Identity (IMDS) | Full | Token endpoint for workload identity |
 | Cloud metadata | Full | Terraform provider metadata |
-| /health | Full | 24 services listed |
+| /health | Full | 25 services listed |
 | /metrics | Full | Uptime, request count, error rate |
 
 ## Not Implemented


### PR DESCRIPTION
## Summary
- Adds `Microsoft.Network/applicationGateways` ARM service emulator with full CRUD operations
- Supports full Application Gateway configuration: SKU (Standard_v2/WAF_v2), gateway IP configs, frontend IP/ports, backend pools, HTTP settings, listeners, routing rules, probes, SSL certs, URL path maps, redirect configs, rewrite rule sets, autoscale, and WAF config
- Includes Terraform example (`examples/terraform/appgateway.tf`) with subnet, public IP, and full app gateway config
- Registered as `appgw` service (filterable via `SERVICES` env var)

## Test plan
- [x] `TestAppGatewayLifecycle` — create with full config (sku, frontends, backends, listeners, rules, probes), get, list, update (SKU change + add backend pool), delete, 404 on deleted
- [x] `TestAppGatewayDefaultSku` — creates minimal gateway, verifies default Standard_v2 SKU and location passthrough
- [x] Live tested against running miniblue instance with curl (create 201, get 200, delete 202, 404 on deleted)
- [x] All existing tests continue to pass