### PR TITLE
fix: preserve resource tags across all ARM services

### DIFF
--- a/internal/services/appgw/handler.go
+++ b/internal/services/appgw/handler.go
@@ -69,11 +69,17 @@ func buildResponse(sub, rg, name string, input map[string]interface{}) map[strin
 		}
 	}
 
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
 	result := map[string]interface{}{
 		"id":       id,
 		"name":     name,
 		"type":     "Microsoft.Network/applicationGateways",
 		"location": location,
+		"tags":     tags,
 		"etag":     "W/\"miniblue\"",
 		"properties": map[string]interface{}{
 			"provisioningState":            "Succeeded",

--- a/internal/services/dns/handler.go
+++ b/internal/services/dns/handler.go
@@ -10,11 +10,12 @@ import (
 )
 
 type Zone struct {
-	ID         string    `json:"id"`
-	Name       string    `json:"name"`
-	Type       string    `json:"type"`
-	Location   string    `json:"location"`
-	Properties ZoneProps `json:"properties"`
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Location   string                 `json:"location"`
+	Tags       map[string]interface{} `json:"tags"`
+	Properties ZoneProps              `json:"properties"`
 }
 
 type ZoneProps struct {
@@ -72,6 +73,9 @@ func (h *Handler) CreateOrUpdateZone(w http.ResponseWriter, r *http.Request) {
 	zone.Name = name
 	zone.Type = "Microsoft.Network/dnsZones"
 	zone.Location = "global"
+	if zone.Tags == nil {
+		zone.Tags = map[string]interface{}{}
+	}
 	zone.Properties.NameServers = []string{"ns1-01.azure-dns.com.", "ns2-01.azure-dns.net."}
 
 	k := h.zoneKey(sub, rg, name)

--- a/internal/services/loadbalancer/handler.go
+++ b/internal/services/loadbalancer/handler.go
@@ -104,11 +104,17 @@ func buildResponse(sub, rg, name string, input map[string]interface{}) map[strin
 		sku = map[string]interface{}{"name": "Standard", "tier": "Regional"}
 	}
 
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
 	return map[string]interface{}{
 		"id":       id,
 		"name":     name,
 		"type":     "Microsoft.Network/loadBalancers",
 		"location": location,
+		"tags":     tags,
 		"etag":     "W/\"miniblue\"",
 		"sku":      sku,
 		"properties": map[string]interface{}{

--- a/internal/services/network/handler.go
+++ b/internal/services/network/handler.go
@@ -100,11 +100,17 @@ func buildVNetResponse(sub, rg, name string, input map[string]interface{}) map[s
 		location = "eastus"
 	}
 
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
 	return map[string]interface{}{
 		"id":       id,
 		"name":     name,
 		"type":     "Microsoft.Network/virtualNetworks",
 		"location": location,
+		"tags":     tags,
 		"etag":     "W/\"miniblue\"",
 		"properties": map[string]interface{}{
 			"provisioningState":      "Succeeded",

--- a/internal/services/nsg/handler.go
+++ b/internal/services/nsg/handler.go
@@ -146,11 +146,17 @@ func buildNSGResponse(sub, rg, name string, input map[string]interface{}, securi
 		securityRules = []interface{}{}
 	}
 
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
 	return map[string]interface{}{
 		"id":       id,
 		"name":     name,
 		"type":     "Microsoft.Network/networkSecurityGroups",
 		"location": location,
+		"tags":     tags,
 		"etag":     "W/\"miniblue\"",
 		"properties": map[string]interface{}{
 			"provisioningState":    "Succeeded",

--- a/internal/services/publicip/handler.go
+++ b/internal/services/publicip/handler.go
@@ -79,11 +79,17 @@ func buildResponse(sub, rg, name string, input map[string]interface{}, existingI
 		sku = map[string]interface{}{"name": "Standard", "tier": "Regional"}
 	}
 
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
 	return map[string]interface{}{
 		"id":       id,
 		"name":     name,
 		"type":     "Microsoft.Network/publicIPAddresses",
 		"location": location,
+		"tags":     tags,
 		"sku":      sku,
 		"properties": map[string]interface{}{
 			"provisioningState":       "Succeeded",

--- a/internal/services/storageaccounts/handler.go
+++ b/internal/services/storageaccounts/handler.go
@@ -73,8 +73,28 @@ func (h *Handler) CreateOrUpdateStorageAccount(w http.ResponseWriter, r *http.Re
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "accountName")
 
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
 	k := h.storageAccountKey(sub, rg, name)
 	acct := h.buildStorageAccountResponse(sub, rg, name)
+	if input != nil {
+		if tags, ok := input["tags"].(map[string]interface{}); ok {
+			acct["tags"] = tags
+		}
+		if loc, ok := input["location"].(string); ok && loc != "" {
+			acct["location"] = loc
+		}
+		if kind, ok := input["kind"].(string); ok && kind != "" {
+			acct["kind"] = kind
+		}
+		if sku, ok := input["sku"].(map[string]interface{}); ok {
+			acct["sku"] = sku
+		}
+	}
+	if acct["tags"] == nil {
+		acct["tags"] = map[string]interface{}{}
+	}
 	h.store.Set(k, acct)
 	storageauth.PersistSharedKeyContext(h.store, sub, rg, name)
 

--- a/tests/tags_test.go
+++ b/tests/tags_test.go
@@ -1,0 +1,170 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestVNetTagsPreserved(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/tagged-vnet"+av,
+		`{"location":"eastus","tags":{"env":"prod","team":"platform"},"properties":{"addressSpace":{"addressPrefixes":["10.0.0.0/16"]}}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	tags, ok := m["tags"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tags in response, got %T", m["tags"])
+	}
+	if tags["env"] != "prod" {
+		t.Fatalf("expected tag env=prod, got %v", tags["env"])
+	}
+	if tags["team"] != "platform" {
+		t.Fatalf("expected tag team=platform, got %v", tags["team"])
+	}
+
+	resp = doRequest(t, "GET", base+"/tagged-vnet"+av, "")
+	expectStatus(t, resp, 200)
+	got := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	gotTags, ok := got["tags"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tags on GET, got %T", got["tags"])
+	}
+	if gotTags["env"] != "prod" {
+		t.Fatalf("GET: expected tag env=prod, got %v", gotTags["env"])
+	}
+
+	doRequest(t, "DELETE", base+"/tagged-vnet"+av, "").Body.Close()
+}
+
+func TestNSGTagsPreserved(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/tagged-nsg"+av,
+		`{"location":"eastus","tags":{"env":"staging"}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	tags := m["tags"].(map[string]interface{})
+	if tags["env"] != "staging" {
+		t.Fatalf("expected tag env=staging, got %v", tags["env"])
+	}
+
+	doRequest(t, "DELETE", base+"/tagged-nsg"+av, "").Body.Close()
+}
+
+func TestPublicIPTagsPreserved(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/tagged-pip"+av,
+		`{"location":"eastus","tags":{"cost-center":"12345"}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	tags := m["tags"].(map[string]interface{})
+	if tags["cost-center"] != "12345" {
+		t.Fatalf("expected tag cost-center=12345, got %v", tags["cost-center"])
+	}
+
+	doRequest(t, "DELETE", base+"/tagged-pip"+av, "").Body.Close()
+}
+
+func TestLoadBalancerTagsPreserved(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/tagged-lb"+av,
+		`{"location":"eastus","tags":{"managed-by":"terraform"}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	tags := m["tags"].(map[string]interface{})
+	if tags["managed-by"] != "terraform" {
+		t.Fatalf("expected tag managed-by=terraform, got %v", tags["managed-by"])
+	}
+
+	doRequest(t, "DELETE", base+"/tagged-lb"+av, "").Body.Close()
+}
+
+func TestAppGatewayTagsPreserved(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/tagged-appgw"+av,
+		`{"location":"eastus","tags":{"owner":"devops"},"properties":{}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	tags := m["tags"].(map[string]interface{})
+	if tags["owner"] != "devops" {
+		t.Fatalf("expected tag owner=devops, got %v", tags["owner"])
+	}
+
+	doRequest(t, "DELETE", base+"/tagged-appgw"+av, "").Body.Close()
+}
+
+func TestDNSZoneTagsPreserved(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/dnsZones"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/tagged.example.com"+av,
+		`{"location":"global","tags":{"zone-type":"public"}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	tags, ok := m["tags"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tags on DNS zone, got %T", m["tags"])
+	}
+	if tags["zone-type"] != "public" {
+		t.Fatalf("expected tag zone-type=public, got %v", tags["zone-type"])
+	}
+
+	doRequest(t, "DELETE", base+"/tagged.example.com"+av, "").Body.Close()
+}
+
+func TestEmptyTagsReturnsEmptyMap(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/no-tags-vnet"+av,
+		`{"location":"eastus","properties":{"addressSpace":{"addressPrefixes":["10.0.0.0/16"]}}}`)
+	expectStatus(t, resp, 201)
+	m := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	tags, ok := m["tags"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tags to be empty map, got %T", m["tags"])
+	}
+	if len(tags) != 0 {
+		t.Fatalf("expected 0 tags, got %d", len(tags))
+	}
+
+	doRequest(t, "DELETE", base+"/no-tags-vnet"+av, "").Body.Close()
+}


### PR DESCRIPTION
## Summary

Fixes #73

Tags were silently dropped on every ARM resource except Resource Groups. This caused constant Terraform drift for any resource with tags.

**Services fixed**: VNets, NSGs, Public IPs, Load Balancers, Application Gateways, DNS Zones, Storage Accounts

**What changed**:
- Each `buildResponse` function now extracts `tags` from input and includes them in the response
- Resources without tags get an empty map (not null) to match Azure behavior
- Storage accounts now also preserve `location`, `kind` and `sku` from the request body
- DNS Zone struct now has a Tags field

## Test plan
- [x] 7 new tests in `tests/tags_test.go` covering tags on VNet, NSG, Public IP, LB, App Gateway, DNS Zone and empty tags
- [x] Full test suite passes (including all 34 ARM tests)