### PR TITLE
fix: add subscription-level list endpoints for networking services

### DIFF
--- a/internal/services/appgw/handler.go
+++ b/internal/services/appgw/handler.go
@@ -27,10 +27,17 @@ func (h *Handler) Register(r chi.Router) {
 			r.Delete("/", h.Delete)
 		})
 	})
+	r.Get("/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways", h.ListInSubscription)
 }
 
 func (h *Handler) key(sub, rg, name string) string {
 	return "appgw:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) ListInSubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("appgw:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }
 
 func getArray(props map[string]interface{}, field string) []interface{} {

--- a/internal/services/dns/handler.go
+++ b/internal/services/dns/handler.go
@@ -51,6 +51,13 @@ func (h *Handler) Register(r chi.Router) {
 			})
 		})
 	})
+	r.Get("/subscriptions/{subscriptionId}/providers/Microsoft.Network/dnsZones", h.ListZonesInSubscription)
+}
+
+func (h *Handler) ListZonesInSubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("dns:zone:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }
 
 func (h *Handler) zoneKey(sub, rg, name string) string {

--- a/internal/services/loadbalancer/handler.go
+++ b/internal/services/loadbalancer/handler.go
@@ -54,10 +54,17 @@ func (h *Handler) Register(r chi.Router) {
 			})
 		})
 	})
+	r.Get("/subscriptions/{subscriptionId}/providers/Microsoft.Network/loadBalancers", h.ListInSubscription)
 }
 
 func (h *Handler) key(sub, rg, name string) string {
 	return "lb:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) ListInSubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("lb:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }
 
 func (h *Handler) backendPoolKey(sub, rg, lb, pool string) string {

--- a/internal/services/network/handler.go
+++ b/internal/services/network/handler.go
@@ -73,6 +73,13 @@ func (h *Handler) Register(r chi.Router) {
 			})
 		})
 	})
+	r.Get("/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks", h.ListVNetsInSubscription)
+}
+
+func (h *Handler) ListVNetsInSubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("vnet:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }
 
 func (h *Handler) vnetKey(sub, rg, name string) string {

--- a/internal/services/nsg/handler.go
+++ b/internal/services/nsg/handler.go
@@ -35,6 +35,13 @@ func (h *Handler) Register(r chi.Router) {
 			})
 		})
 	})
+	r.Get("/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups", h.ListNSGsInSubscription)
+}
+
+func (h *Handler) ListNSGsInSubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("nsg:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }
 
 func (h *Handler) nsgKey(sub, rg, name string) string {

--- a/internal/services/publicip/handler.go
+++ b/internal/services/publicip/handler.go
@@ -30,10 +30,17 @@ func (h *Handler) Register(r chi.Router) {
 			r.Delete("/", h.Delete)
 		})
 	})
+	r.Get("/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses", h.ListInSubscription)
 }
 
 func (h *Handler) key(sub, rg, name string) string {
 	return "publicip:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) ListInSubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("publicip:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }
 
 func nextIP() string {

--- a/tests/subscriptionlist_test.go
+++ b/tests/subscriptionlist_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestListVNetsInSubscription(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	av := "?api-version=2023-09-01"
+	base := ts.URL + "/subscriptions/sub1"
+
+	doRequest(t, "PUT", base+"/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet-a"+av,
+		`{"location":"eastus","properties":{"addressSpace":{"addressPrefixes":["10.0.0.0/16"]}}}`).Body.Close()
+	doRequest(t, "PUT", base+"/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/vnet-b"+av,
+		`{"location":"westus","properties":{"addressSpace":{"addressPrefixes":["10.1.0.0/16"]}}}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+"/providers/Microsoft.Network/virtualNetworks"+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	items := list["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 VNets across RGs, got %d", len(items))
+	}
+}
+
+func TestListNSGsInSubscription(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	av := "?api-version=2023-09-01"
+	base := ts.URL + "/subscriptions/sub1"
+
+	doRequest(t, "PUT", base+"/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg-a"+av,
+		`{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg-b"+av,
+		`{"location":"westus"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+"/providers/Microsoft.Network/networkSecurityGroups"+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	items := list["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 NSGs across RGs, got %d", len(items))
+	}
+}
+
+func TestListPublicIPsInSubscription(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	av := "?api-version=2023-09-01"
+	base := ts.URL + "/subscriptions/sub1"
+
+	doRequest(t, "PUT", base+"/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip-a"+av,
+		`{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/resourceGroups/rg2/providers/Microsoft.Network/publicIPAddresses/pip-b"+av,
+		`{"location":"westus"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+"/providers/Microsoft.Network/publicIPAddresses"+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	items := list["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 PIPs across RGs, got %d", len(items))
+	}
+}
+
+func TestListLoadBalancersInSubscription(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	av := "?api-version=2023-09-01"
+	base := ts.URL + "/subscriptions/sub1"
+
+	doRequest(t, "PUT", base+"/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb-a"+av,
+		`{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/resourceGroups/rg2/providers/Microsoft.Network/loadBalancers/lb-b"+av,
+		`{"location":"westus"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+"/providers/Microsoft.Network/loadBalancers"+av, "")
+	expectStatus(t, resp, 200)
+	list := decodeJSON(t, resp)
+	resp.Body.Close()
+
+	items := list["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 LBs across RGs, got %d", len(items))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #47 (partial)

Terraform data sources and some SDK operations call subscription-scoped list endpoints to find resources across all resource groups. These endpoints were missing for networking services, causing 404s.

**Endpoints added**:
- `GET /subscriptions/{sub}/providers/Microsoft.Network/virtualNetworks`
- `GET /subscriptions/{sub}/providers/Microsoft.Network/networkSecurityGroups`
- `GET /subscriptions/{sub}/providers/Microsoft.Network/publicIPAddresses`
- `GET /subscriptions/{sub}/providers/Microsoft.Network/loadBalancers`
- `GET /subscriptions/{sub}/providers/Microsoft.Network/applicationGateways`
- `GET /subscriptions/{sub}/providers/Microsoft.Network/dnsZones`

Storage accounts already had this endpoint.

## Test plan
- [x] 4 new tests verifying cross-resource-group listing for VNets, NSGs, Public IPs and Load Balancers
- [x] Full test suite passes