### PR TITLE
fix: inject version via ldflags in all build targets

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -39,8 +39,10 @@ jobs:
         run: |
           EXT=""
           if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
-          go build -ldflags="-s -w" -o miniblue-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} ./cmd/miniblue
-          go build -ldflags="-s -w" -o azlocal-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} ./cmd/azlocal
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          LDFLAGS="-s -w -X github.com/moabukar/miniblue/internal/server.Version=${VERSION}"
+          go build -ldflags="${LDFLAGS}" -o miniblue-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} ./cmd/miniblue
+          go build -ldflags="${LDFLAGS}" -o azlocal-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} ./cmd/azlocal
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
             type=semver,pattern={{version}}
             type=sha
 
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
@@ -54,6 +58,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ steps.version.outputs.VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	golangci-lint run
 
 docker-build:
-	docker build -t $(DOCKER_IMAGE):latest .
+	docker build --build-arg VERSION=$(VERSION) -t $(DOCKER_IMAGE):latest .
 
 docker-run:
 	docker run -p 4566:4566 -p 4567:4567 $(DOCKER_IMAGE):latest


### PR DESCRIPTION
## Summary

`miniblue --version` shows `dev` instead of the actual version because the build-time ldflags were missing from the binary release workflow and Docker release workflow.

**Fixed**:
- `binaries.yml` - extracts version from git tag and passes `-X server.Version` via ldflags
- `release.yml` - passes `--build-arg VERSION` to Docker build so the Dockerfile ARG is set
- `Makefile` - docker-build target now passes `--build-arg VERSION`
- Homebrew formula already fixed separately in moabukar/homebrew-tap

After this, `miniblue --version` will show `miniblue 0.4.2` (or whatever the release tag is).

## Test plan
- [x] Only workflow YAML and Makefile changes, no Go code modified
- [x] Dockerfile already has `ARG VERSION=dev` and the `-X` ldflags, just needed the arg passed in