### PR TITLE
fix: store backend data race and nil slice bugs

### DIFF
--- a/internal/store/file.go
+++ b/internal/store/file.go
@@ -48,13 +48,7 @@ func (f *FileBackend) Save() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	keys := f.mem.List()
-	state := make(map[string]interface{}, len(keys))
-	for _, k := range keys {
-		if v, ok := f.mem.Get(k); ok {
-			state[k] = v
-		}
-	}
+	state := f.mem.Snapshot()
 	data, err := json.Marshal(state)
 	if err != nil {
 		return err

--- a/internal/store/file_test.go
+++ b/internal/store/file_test.go
@@ -96,6 +96,63 @@ func TestFileBackend_AutoSave(t *testing.T) {
 	}
 }
 
+func TestFileBackend_ConcurrentWriteDuringSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	fb := NewFileBackend(path)
+
+	for i := 0; i < 100; i++ {
+		fb.Set("key-"+string(rune('a'+i%26)), i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for j := 0; j < 50; j++ {
+			fb.Set("concurrent", j)
+			fb.Delete("key-a")
+			fb.Set("key-a", j*10)
+		}
+		close(done)
+	}()
+
+	for k := 0; k < 10; k++ {
+		if err := fb.Save(); err != nil {
+			t.Errorf("Save() error during concurrent writes: %v", err)
+		}
+	}
+	<-done
+
+	if err := fb.Save(); err != nil {
+		t.Fatalf("final Save() error: %v", err)
+	}
+
+	fb2 := NewFileBackend(path)
+	if _, ok := fb2.Get("concurrent"); !ok {
+		t.Error("key 'concurrent' missing after concurrent save/write")
+	}
+}
+
+func TestMemoryBackend_Snapshot(t *testing.T) {
+	m := NewMemoryBackend()
+	m.Set("a", 1)
+	m.Set("b", 2)
+
+	snap := m.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 keys in snapshot, got %d", len(snap))
+	}
+
+	m.Set("c", 3)
+	m.Delete("a")
+
+	if len(snap) != 2 {
+		t.Fatalf("snapshot should be isolated from mutations, got %d keys", len(snap))
+	}
+	if snap["a"] != 1 {
+		t.Errorf("snapshot should still have a=1, got %v", snap["a"])
+	}
+}
+
 func TestStore_StartAutoSave_NoOp_MemoryBackend(t *testing.T) {
 	s := New() // memory backend
 	stop := s.StartAutoSave(10 * time.Millisecond)

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -113,6 +113,16 @@ func (m *MemoryBackend) Reset() {
 	m.data = make(map[string]interface{})
 }
 
+func (m *MemoryBackend) Snapshot() map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	snapshot := make(map[string]interface{}, len(m.data))
+	for k, v := range m.data {
+		snapshot[k] = v
+	}
+	return snapshot
+}
+
 // Store wraps a Backend and provides the public API used by all handlers.
 // It preserves backward compatibility -- handlers continue to use *store.Store.
 type Store struct {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -77,11 +77,11 @@ func (p *PostgresBackend) Delete(key string) bool {
 func (p *PostgresBackend) List() []string {
 	rows, err := p.db.Query(`SELECT key FROM miniblue_store`)
 	if err != nil {
-		return nil
+		return []string{}
 	}
 	defer rows.Close()
 
-	var keys []string
+	keys := make([]string, 0)
 	for rows.Next() {
 		var k string
 		if err := rows.Scan(&k); err == nil {
@@ -97,11 +97,11 @@ func (p *PostgresBackend) ListByPrefix(prefix string) []interface{} {
 		prefix+"%",
 	)
 	if err != nil {
-		return nil
+		return []interface{}{}
 	}
 	defer rows.Close()
 
-	var results []interface{}
+	results := make([]interface{}, 0)
 	for rows.Next() {
 		var data []byte
 		if err := rows.Scan(&data); err != nil {


### PR DESCRIPTION
## Summary

Fixes #84 and #89

### Data race in FileBackend.Save() (#84)

**Before**: `Save()` called `f.mem.List()` then looped calling `f.mem.Get()` for each key. Between these calls, handler goroutines could delete or modify keys, causing `Save()` to read inconsistent state.

```go
// Before: two separate locked operations, race between them
keys := f.mem.List()          // lock, read keys, unlock
for _, k := range keys {
    v, ok := f.mem.Get(k)     // lock, read value, unlock (key may be gone)
    state[k] = v
}
```

**After**: Added `Snapshot()` to MemoryBackend that copies the entire map under a single read lock. `Save()` now calls `Snapshot()` once, getting a consistent point-in-time copy.

```go
// After: single atomic read of entire state
state := f.mem.Snapshot()     // lock, copy all, unlock
data, _ := json.Marshal(state)
```

### PostgresBackend returns nil instead of empty slice (#89)

**Before**: `List()` and `ListByPrefix()` returned `nil` on error. MemoryBackend returns `[]string{}` and `[]interface{}{}`. Callers ranging over a nil slice work fine in Go, but callers checking `len()` or passing to `json.Encode` get inconsistent behavior.

```go
// Before
return nil  // nil != empty slice for JSON encoding
```

**After**: Returns initialized empty slices on error, matching MemoryBackend behavior.

```go
// After
return []string{}
return []interface{}{}
```

## Test plan
- [x] `TestFileBackend_ConcurrentWriteDuringSave` - 50 concurrent writes while Save runs 10 times, verifies no data loss
- [x] `TestMemoryBackend_Snapshot` - verifies snapshot is isolated from subsequent mutations
- [x] All existing store tests pass
- [x] Full test suite passes