### PR TITLE
fix: run E2E tests on PRs and pushes to main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,9 @@
 name: E2E Test
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/examples/ci/github-actions.yml
+++ b/examples/ci/github-actions.yml
@@ -15,7 +15,7 @@ jobs:
         options: --health-cmd="/healthcheck" --health-interval=5s --health-retries=5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Wait for miniblue
         run: |


### PR DESCRIPTION
## Summary

Fixes #82 and #91

### E2E tests now run automatically (#82)

**Before**: The E2E workflow only ran on `workflow_dispatch` (manual trigger). Breaking changes in handlers could slip through PRs without catching regressions.

```yaml
# Before
on:
  workflow_dispatch:
```

**After**: Runs on every push to main and every PR.

```yaml
# After
on:
  push:
    branches: [main]
  pull_request:
  workflow_dispatch:
```

### CI example updated (#91)

Updated `examples/ci/github-actions.yml` from `actions/checkout@v4` to `@v6` to match the versions used in the main repo workflows.

## Test plan
- [x] Workflow YAML changes only, no Go code modified
- [x] E2E workflow will run on this PR as proof it works