### PR TITLE
fix: handle errors in azlocal CLI instead of silently swallowing them

### DIFF
--- a/cmd/azlocal/main.go
+++ b/cmd/azlocal/main.go
@@ -219,7 +219,11 @@ func doGet(path string) {
 }
 
 func doPut(path string, body interface{}) {
-	data, _ := json.Marshal(body)
+	data, err := json.Marshal(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to encode request body: %v\n", err)
+		os.Exit(1)
+	}
 	req, _ := http.NewRequest("PUT", baseURL+armPath(path), bytes.NewReader(data))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -263,7 +267,11 @@ func doDelete(path string) {
 }
 
 func doPost(path string, body interface{}) {
-	data, _ := json.Marshal(body)
+	data, err := json.Marshal(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to encode request body: %v\n", err)
+		os.Exit(1)
+	}
 	resp, err := http.Post(baseURL+armPath(path), "application/json", bytes.NewReader(data))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -274,7 +282,11 @@ func doPost(path string, body interface{}) {
 }
 
 func printResponse(resp *http.Response) {
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to read response: %v\n", err)
+		return
+	}
 	if len(body) == 0 {
 		return
 	}


### PR DESCRIPTION
## Summary

Fixes #85

### JSON marshal errors silently swallowed

**Before**: If `json.Marshal` failed, an empty body was sent to the server. The user would get a confusing error from the server with no indication of what went wrong.

```go
// Before: error silently ignored
data, _ := json.Marshal(body)
```

**After**: Prints a clear error message and exits.

```go
// After: fails fast with a useful message
data, err := json.Marshal(body)
if err != nil {
    fmt.Fprintf(os.Stderr, "Error: failed to encode request body: %v\n", err)
    os.Exit(1)
}
```

### Response read errors silently swallowed

**Before**: If `io.ReadAll` failed, the CLI printed nothing - the user had no idea if the operation succeeded or failed.

```go
// Before
body, _ := io.ReadAll(resp.Body)
```

**After**: Prints an error to stderr and returns.

```go
// After
body, err := io.ReadAll(resp.Body)
if err != nil {
    fmt.Fprintf(os.Stderr, "Error: failed to read response: %v\n", err)
    return
}
```

Fixed in `doPut`, `doPost` and `printResponse`.

## Test plan
- [x] `go build ./cmd/azlocal/` compiles
- [x] No behavior change for the happy path