### PR TITLE
feat: add app service and move the logic of azure functions to sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docker-compose.override.yml
 *.tfstate
 *.tfstate.backup
 .terraform.lock.hcl
+.terraform.tfstate.lock.info
 .terraform.tfstate.lock.hcl
 
 # Python
@@ -57,3 +58,6 @@ package-lock.json
 
 # Certificates
 .miniblue/
+
+# Debug
+__debug_bin*

--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,13 @@
+// Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger
+[
+  {
+    "label": "Go (Delve)",
+    "adapter": "Delve",
+    "program": "$ZED_FILE",
+    "request": "launch",
+    "mode": "debug"
+  }
+]

--- a/cmd/azlocal/main.go
+++ b/cmd/azlocal/main.go
@@ -60,6 +60,8 @@ func main() {
 		handleMySQL(args[1:])
 	case "aci":
 		handleACI(args[1:])
+	case "containerapp":
+		handleContainerApp(args[1:])
 	case "table":
 		handleTable(args[1:])
 	case "queue":
@@ -100,6 +102,7 @@ Commands:
   sql          Azure SQL Database operations
   mysql        Azure Database for MySQL operations
   aci          Azure Container Instances operations
+  containerapp Azure Container Apps operations
   table        Azure Table Storage operations
   queue        Azure Queue Storage operations
   reset        Reset all miniblue state
@@ -149,6 +152,15 @@ Examples:
 
   azlocal aci create --resource-group myRG --name mygroup --image nginx --location eastus
   azlocal aci list --resource-group myRG
+
+  azlocal containerapp env create --resource-group myRG --name myenv --location eastus
+  azlocal containerapp env list --resource-group myRG
+  azlocal containerapp env show --resource-group myRG --name myenv
+
+  azlocal containerapp create --resource-group myRG --name myapp --image nginx --environment myenv
+  azlocal containerapp list --resource-group myRG
+  azlocal containerapp show --resource-group myRG --name myapp
+  azlocal containerapp delete --resource-group myRG --name myapp
 
   azlocal table create --account myaccount --name mytable
   azlocal table entity put --account myaccount --table mytable --partition-key pk1 --row-key rk1 --data '{"foo":"bar"}'
@@ -1289,5 +1301,167 @@ func handleQueueMessage(args []string) {
 		doDelete(base)
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown subcommand: queue message %s\n", args[0])
+	}
+}
+
+// --- Container Apps ---
+
+func handleContainerApp(args []string) {
+	if len(args) == 0 {
+		fmt.Println(`Usage:
+  azlocal containerapp <create|show|list|delete> [flags]
+  azlocal containerapp env <create|show|list|delete> [flags]`)
+		return
+	}
+	switch args[0] {
+	case "env":
+		handleContainerAppEnv(args[1:])
+	case "create", "show", "list", "delete":
+		handleContainerAppOps(args[0:])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown subcommand: containerapp %s\n", args[0])
+	}
+}
+
+func handleContainerAppEnv(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: azlocal containerapp env <create|show|list|delete> [flags]")
+		return
+	}
+	// Check if it's not a subcommand (like 'create')
+	if args[0] == "create" || args[0] == "show" || args[0] == "list" || args[0] == "delete" {
+		handleContainerAppEnvOps(args[0:])
+	} else {
+		fmt.Println("Usage: azlocal containerapp env <create|show|list|delete> [flags]")
+	}
+}
+
+func handleContainerAppEnvOps(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: azlocal containerapp env <create|show|list|delete> [flags]")
+		return
+	}
+	op := args[0]
+	rg := requireFlag(args, "resource-group")
+	s := sub(args)
+	base := "/subscriptions/" + s + "/resourceGroups/" + rg + "/providers/Microsoft.App/managedEnvironments"
+
+	switch op {
+	case "create":
+		name := requireFlag(args, "name")
+		location := getFlag(args, "location")
+		if location == "" {
+			location = "eastus"
+		}
+
+		props := map[string]interface{}{}
+		logsID := getFlag(args, "logs-workspace-id")
+		logsKey := getFlag(args, "logs-workspace-key")
+		if logsID != "" && logsKey != "" {
+			props["appLogsConfiguration"] = map[string]interface{}{
+				"logAnalytics": map[string]string{
+					"workspaceId": logsID,
+					"sharedKey":   logsKey,
+				},
+			}
+		}
+
+		doPut(base+"/"+name, map[string]interface{}{
+			"location":   location,
+			"properties": props,
+		})
+	case "show":
+		name := requireFlag(args, "name")
+		doGet(base + "/" + name)
+	case "list":
+		doGet(base)
+	case "delete":
+		name := requireFlag(args, "name")
+		doDelete(base + "/" + name)
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown subcommand: containerapp env %s\n", op)
+	}
+}
+
+func handleContainerAppOps(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: azlocal containerapp <create|show|list|delete> [flags]")
+		return
+	}
+	op := args[0]
+	rg := requireFlag(args, "resource-group")
+	s := sub(args)
+	base := "/subscriptions/" + s + "/resourceGroups/" + rg + "/providers/Microsoft.App/containerApps"
+
+	switch op {
+	case "create":
+		name := requireFlag(args, "name")
+		location := getFlag(args, "location")
+		if location == "" {
+			location = "eastus"
+		}
+		image := getFlag(args, "image")
+		if image == "" {
+			image = "nginx:latest"
+		}
+		envName := getFlag(args, "environment")
+		ingress := getFlag(args, "ingress")
+		if ingress == "" {
+			ingress = "external"
+		}
+		targetPort := getFlag(args, "target-port")
+		if targetPort == "" {
+			targetPort = "80"
+		}
+		cpu := getFlag(args, "cpu")
+		if cpu == "" {
+			cpu = "0.5"
+		}
+		memory := getFlag(args, "memory")
+		if memory == "" {
+			memory = "1Gi"
+		}
+
+		props := map[string]interface{}{}
+		if envName != "" {
+			envID := "/subscriptions/" + s + "/resourceGroups/" + rg + "/providers/Microsoft.App/managedEnvironments/" + envName
+			props["environmentId"] = envID
+			props["managedEnvironmentId"] = envID
+		}
+
+		props["configuration"] = map[string]interface{}{
+			"ingress": map[string]interface{}{
+				"external":   ingress == "external",
+				"targetPort": targetPort,
+			},
+		}
+
+		props["template"] = map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  name,
+					"image": image,
+					"resources": map[string]interface{}{
+						"cpu":    cpu,
+						"memory": memory,
+					},
+				},
+			},
+		}
+
+		doPut(base+"/"+name, map[string]interface{}{
+			"location":   location,
+			"properties": props,
+		})
+	case "show":
+		name := requireFlag(args, "name")
+		doGet(base + "/" + name)
+	case "list":
+		doGet(base)
+	case "delete":
+		name := requireFlag(args, "name")
+		doDelete(base + "/" + name)
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown subcommand: containerapp %s\n", op)
 	}
 }

--- a/examples/terraform/scenarios/README.md
+++ b/examples/terraform/scenarios/README.md
@@ -9,6 +9,7 @@ Example architectures you can test locally with miniblue.
 | [three-tier](three-tier/) | Web + App + Data tier with VNet isolation | RG, VNet, 3 Subnets, DNS, ACR |
 | [serverless](serverless/) | Event-driven with Functions and Event Grid | RG, Event Grid, DNS |
 | [microservices](microservices/) | Multi-service with shared infra and per-service subnets | 4 RGs, VNet, 3 Subnets, ACR, DNS, Event Grid |
+| [webapps](webapps/) | App Service with Linux Web App | RG, App Service Plan, Linux Web App |
 
 ## Running any scenario
 

--- a/examples/terraform/scenarios/README.md
+++ b/examples/terraform/scenarios/README.md
@@ -9,6 +9,7 @@ Example architectures you can test locally with miniblue.
 | [three-tier](three-tier/) | Web + App + Data tier with VNet isolation | RG, VNet, 3 Subnets, DNS, ACR |
 | [serverless](serverless/) | Event-driven with Functions and Event Grid | RG, Event Grid, DNS |
 | [microservices](microservices/) | Multi-service with shared infra and per-service subnets | 4 RGs, VNet, 3 Subnets, ACR, DNS, Event Grid |
+| [containerapps](containerapps/) | Container Apps with Managed Environments and Jobs | RG, Managed Environment, 2 Container Apps, Container App Job |
 | [webapps](webapps/) | App Service with Linux Web App | RG, App Service Plan, Linux Web App |
 
 ## Running any scenario

--- a/examples/terraform/scenarios/containerapps/main.tf
+++ b/examples/terraform/scenarios/containerapps/main.tf
@@ -1,0 +1,122 @@
+# Container Apps Architecture on miniblue
+# Managed Environments + Container Apps + Jobs
+#
+# Usage:
+#   export SSL_CERT_FILE=~/.miniblue/cert.pem
+#   terraform init && terraform apply -auto-approve
+#
+# Test with azlocal after apply:
+#   azlocal group list
+#   azlocal managed-environment show --name apps-env --resource-group containerapps-rg
+#   azlocal container-app show --name api-app --resource-group containerapps-rg
+#   azlocal container-app show --name web-app --resource-group containerapps-rg
+#   azlocal container-app-job show --name batch-job --resource-group containerapps-rg
+#   azlocal container-app revision list --name api-app --resource-group containerapps-rg
+#
+# Destroy:
+#   terraform destroy -auto-approve
+
+# --- Foundation ---
+
+resource "azurerm_resource_group" "main" {
+  name     = "containerapps-rg"
+  location = "East US"
+}
+
+# --- Managed Environment ---
+
+resource "azurerm_container_app_environment" "apps" {
+  name                = "apps-env"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+}
+
+# --- Container Apps ---
+
+resource "azurerm_container_app" "api" {
+  name                         = "api-app"
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = azurerm_container_app_environment.apps.id
+  revision_mode                = "Single"
+
+  ingress {
+    target_port      = 8080
+    external_enabled = true
+    transport        = "http"
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
+  template {
+    container {
+      name   = "api"
+      image  = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+}
+
+resource "azurerm_container_app" "web" {
+  name                         = "web-app"
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = azurerm_container_app_environment.apps.id
+  revision_mode                = "Multiple"
+
+  ingress {
+    target_port      = 80
+    external_enabled = true
+    transport        = "http"
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
+  template {
+    min_replicas = 1
+    max_replicas = 3
+
+    container {
+      name   = "web"
+      image  = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+      cpu    = 0.5
+      memory = "1Gi"
+
+      env {
+        name  = "API_URL"
+        value = "https://api-app.hashed.eastus.containerApps.k4apps.io"
+      }
+    }
+  }
+}
+
+# --- Container Apps Jobs ---
+
+resource "azurerm_container_app_job" "batch" {
+  name                         = "batch-job"
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = azurerm_container_app_environment.apps.id
+  location                     = azurerm_resource_group.main.location
+
+  replica_timeout_in_seconds = 600
+  replica_retry_limit        = 3
+
+  manual_trigger_config {
+    parallelism = 1
+    replica_completion_count = 1
+  }
+
+  template {
+    container {
+      name   = "batch"
+      image  = "mcr.microsoft.com/samples/containerapps-batchprocessor:latest"
+      cpu    = 1.0
+      memory = "2Gi"
+    }
+  }
+}

--- a/examples/terraform/scenarios/containerapps/main.tf
+++ b/examples/terraform/scenarios/containerapps/main.tf
@@ -58,6 +58,11 @@ resource "azurerm_container_app" "api" {
       memory = "0.5Gi"
     }
   }
+
+  secret {
+    name  = "api-key"
+    value = "placeholder-secret-value"
+  }
 }
 
 resource "azurerm_container_app" "web" {
@@ -92,6 +97,11 @@ resource "azurerm_container_app" "web" {
         value = "https://api-app.hashed.eastus.containerApps.k4apps.io"
       }
     }
+  }
+
+  secret {
+    name  = "db-password"
+    value = "placeholder-secret-value"
   }
 }
 

--- a/examples/terraform/scenarios/containerapps/provider.tf
+++ b/examples/terraform/scenarios/containerapps/provider.tf
@@ -1,0 +1,11 @@
+provider "azurerm" {
+  features {}
+
+  metadata_host              = "localhost:4567"
+  skip_provider_registration = true
+
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000001"
+  client_id       = "miniblue"
+  client_secret   = "miniblue"
+}

--- a/examples/terraform/scenarios/containerapps/versions.tf
+++ b/examples/terraform/scenarios/containerapps/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/examples/terraform/scenarios/webapps/main.tf
+++ b/examples/terraform/scenarios/webapps/main.tf
@@ -1,0 +1,43 @@
+# App Service Web Apps Architecture on miniblue
+# Service Plan + Linux Web App for testing azurerm providers
+#
+# Usage:
+#   export SSL_CERT_FILE=~/.miniblue/cert.pem
+#   terraform init && terraform apply -auto-approve
+#
+# Test with azlocal after apply:
+#   azlocal group list
+#   azlocal serviceplan show --name webapp-plan --resource-group webapps-rg
+#   azlocal webapp show --name my-linux-webapp --resource-group webapps-rg
+#
+# Destroy:
+#   terraform destroy -auto-approve
+
+resource "azurerm_resource_group" "webapps" {
+  name     = "webapps-rg"
+  location = "East US"
+}
+
+# --- App Service Plan (Server Farm) ---
+
+resource "azurerm_service_plan" "webapp" {
+  name                = "webapp-plan"
+  resource_group_name = azurerm_resource_group.webapps.name
+  location            = azurerm_resource_group.webapps.location
+  os_type             = "Linux"
+  sku_name            = "P1v2"
+}
+
+# --- Linux Web App ---
+
+resource "azurerm_linux_web_app" "webapp" {
+  name                = "my-linux-webapp"
+  resource_group_name = azurerm_resource_group.webapps.name
+  location            = azurerm_resource_group.webapps.location
+  service_plan_id     = azurerm_service_plan.webapp.id
+
+  site_config {
+    always_on  = false
+    ftps_state = "Disabled"
+  }
+}

--- a/examples/terraform/scenarios/webapps/provider.tf
+++ b/examples/terraform/scenarios/webapps/provider.tf
@@ -1,0 +1,11 @@
+provider "azurerm" {
+  features {}
+
+  metadata_host              = "localhost:4567"
+  skip_provider_registration = true
+
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000001"
+  client_id       = "miniblue"
+  client_secret   = "miniblue"
+}

--- a/examples/terraform/scenarios/webapps/versions.tf
+++ b/examples/terraform/scenarios/webapps/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moabukar/miniblue/internal/services/acr"
 	"github.com/moabukar/miniblue/internal/services/appconfig"
 	"github.com/moabukar/miniblue/internal/services/appgw"
+	"github.com/moabukar/miniblue/internal/services/apps"
 	"github.com/moabukar/miniblue/internal/services/auth"
 	"github.com/moabukar/miniblue/internal/services/blob"
 	"github.com/moabukar/miniblue/internal/services/cosmosdb"
@@ -22,7 +23,6 @@ import (
 	"github.com/moabukar/miniblue/internal/services/dbpostgres"
 	"github.com/moabukar/miniblue/internal/services/dns"
 	"github.com/moabukar/miniblue/internal/services/eventgrid"
-	"github.com/moabukar/miniblue/internal/services/functions"
 	"github.com/moabukar/miniblue/internal/services/identity"
 	"github.com/moabukar/miniblue/internal/services/keyvault"
 	"github.com/moabukar/miniblue/internal/services/loadbalancer"
@@ -33,8 +33,9 @@ import (
 	"github.com/moabukar/miniblue/internal/services/queue"
 	"github.com/moabukar/miniblue/internal/services/redis"
 	"github.com/moabukar/miniblue/internal/services/resourcegroups"
-	"github.com/moabukar/miniblue/internal/services/sqldb"
 	"github.com/moabukar/miniblue/internal/services/servicebus"
+	"github.com/moabukar/miniblue/internal/services/sites"
+	"github.com/moabukar/miniblue/internal/services/sqldb"
 	"github.com/moabukar/miniblue/internal/services/storageaccounts"
 	"github.com/moabukar/miniblue/internal/services/subscriptions"
 	"github.com/moabukar/miniblue/internal/services/table"
@@ -162,7 +163,8 @@ func (s *Server) setupRoutes() {
 		{"keyvault", func() { keyvault.NewHandler(s.store).Register(s.router) }},
 		{"cosmosdb", func() { cosmosdb.NewHandler(s.store).Register(s.router) }},
 		{"servicebus", func() { servicebus.NewHandler(s.store).Register(s.router) }},
-		{"functions", func() { functions.NewHandler(s.store).Register(s.router) }},
+		{"sites", func() { sites.NewHandler(s.store).Register(s.router) }},
+		{"apps", func() { apps.NewHandler(s.store).Register(s.router) }},
 		{"network", func() { network.NewHandler(s.store).Register(s.router) }},
 		{"dns", func() { dns.NewHandler(s.store).Register(s.router) }},
 		{"aci", func() { aci.NewHandler(s.store).Register(s.router) }},
@@ -201,11 +203,11 @@ func (s *Server) metricsHandler(w http.ResponseWriter, r *http.Request) {
 	m := GetMetrics()
 	uptime := time.Since(m.StartTime)
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"uptime_seconds":  int(uptime.Seconds()),
-		"total_requests":  m.TotalRequests.Load(),
-		"total_errors":    m.TotalErrors.Load(),
-		"error_rate":      fmt.Sprintf("%.2f%%", errorRate(m)),
-		"store_backend":   storeBackendName(s.store),
+		"uptime_seconds": int(uptime.Seconds()),
+		"total_requests": m.TotalRequests.Load(),
+		"total_errors":   m.TotalErrors.Load(),
+		"error_rate":     fmt.Sprintf("%.2f%%", errorRate(m)),
+		"store_backend":  storeBackendName(s.store),
 	})
 }
 

--- a/internal/services/apps/containerapps.go
+++ b/internal/services/apps/containerapps.go
@@ -1,0 +1,256 @@
+package apps
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+)
+
+func (h *Handler) containerAppKey(sub, rg, name string) string {
+	return "containerapp:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) RegisterContainerApps(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps", func(r chi.Router) {
+		r.Get("/", h.ListContainerApps)
+		r.Route("/{name}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateContainerApp)
+			r.Get("/", h.GetContainerApp)
+			r.Delete("/", h.DeleteContainerApp)
+
+			r.Route("/revisions", func(r chi.Router) {
+				r.Get("/", h.ListRevisions)
+				r.Route("/{revisionName}", func(r chi.Router) {
+					r.Get("/", h.GetRevision)
+				})
+			})
+
+			r.Post("/start", h.StartContainerApp)
+			r.Post("/stop", h.StopContainerApp)
+		})
+	})
+}
+
+func (h *Handler) buildContainerAppResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/containerApps/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
+	environmentID := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/managedEnvironments/default"
+	if envID, ok := props["environmentId"].(string); ok && envID != "" {
+		environmentID = envID
+	}
+
+	provisioningState := "Succeeded"
+	if state, ok := props["provisioningState"].(string); ok && state != "" {
+		provisioningState = state
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.App/containerApps",
+		"location": location,
+		"tags":     tags,
+		"properties": map[string]interface{}{
+			"provisioningState":          provisioningState,
+			"environmentId":              environmentID,
+			"environmentName":            "default",
+			"latestRevisionName":         name + "-v1",
+			"latestRevisionFqdn":         name + ".hashed.eastus.containerApps.k4apps.io",
+			"fqdn":                       name + ".hashed.eastus.containerApps.k4apps.io",
+			"exposedPort":                props["exposedPort"],
+			"customDomainVerificationId": "miniblue",
+			"configuration":              props["configuration"],
+			"template":                   props["template"],
+			"managedBy":                  props["managedBy"],
+			"workloadProfileName":        props["workloadProfileName"],
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateContainerApp(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	app := h.buildContainerAppResponse(sub, rg, name, input)
+	k := h.containerAppKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, app)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(app)
+}
+
+func (h *Handler) GetContainerApp(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteContainerApp(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	if !h.store.Delete(h.containerAppKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) ListContainerApps(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("containerapp:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+func (h *Handler) ListRevisions(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps/revisions", name)
+		return
+	}
+
+	app, _ := v.(map[string]interface{})
+	props, _ := app["properties"].(map[string]interface{})
+	revisionName, _ := props["latestRevisionName"].(string)
+	revisionFqdn, _ := props["latestRevisionFqdn"].(string)
+
+	revision := map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/containerApps/" + name + "/revisions/" + revisionName,
+		"name": revisionName,
+		"type": "Microsoft.App/containerApps/revisions",
+		"properties": map[string]interface{}{
+			"createdTime":    "2024-01-01T00:00:00Z",
+			"lastActiveTime": "2024-01-01T00:00:00Z",
+			"fqdn":           revisionFqdn,
+			"active":         true,
+			"replicas":       1,
+			"runningState":   "Running",
+		},
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": []interface{}{revision}})
+}
+
+func (h *Handler) GetRevision(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+	revisionName := chi.URLParam(r, "revisionName")
+
+	v, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps/revisions", revisionName)
+		return
+	}
+
+	app, _ := v.(map[string]interface{})
+	props, _ := app["properties"].(map[string]interface{})
+	revisionFqdn, _ := props["latestRevisionFqdn"].(string)
+
+	revision := map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/containerApps/" + name + "/revisions/" + revisionName,
+		"name": revisionName,
+		"type": "Microsoft.App/containerApps/revisions",
+		"properties": map[string]interface{}{
+			"createdTime":    "2024-01-01T00:00:00Z",
+			"lastActiveTime": "2024-01-01T00:00:00Z",
+			"fqdn":           revisionFqdn,
+			"active":         true,
+			"replicas":       1,
+			"runningState":   "Running",
+		},
+	}
+
+	json.NewEncoder(w).Encode(revision)
+}
+
+func (h *Handler) StartContainerApp(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	app, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	props, _ := app["properties"].(map[string]interface{})
+	props["provisioningState"] = "Succeeded"
+	app["properties"] = props
+	h.store.Set(h.containerAppKey(sub, rg, name), app)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(app)
+}
+
+func (h *Handler) StopContainerApp(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	app, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	props, _ := app["properties"].(map[string]interface{})
+	props["provisioningState"] = "Degraded"
+	app["properties"] = props
+	h.store.Set(h.containerAppKey(sub, rg, name), app)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(app)
+}

--- a/internal/services/apps/containerapps.go
+++ b/internal/services/apps/containerapps.go
@@ -8,6 +8,30 @@ import (
 	"github.com/moabukar/miniblue/internal/azerr"
 )
 
+func sanitizeEmptyStrings(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		result := make(map[string]any)
+		for k, v := range val {
+			result[k] = sanitizeEmptyStrings(v)
+		}
+		return result
+	case []any:
+		result := make([]any, len(val))
+		for i, v := range val {
+			result[i] = sanitizeEmptyStrings(v)
+		}
+		return result
+	case string:
+		if val == "" {
+			return nil
+		}
+		return val
+	default:
+		return v
+	}
+}
+
 func (h *Handler) containerAppKey(sub, rg, name string) string {
 	return "containerapp:" + sub + ":" + rg + ":" + name
 }
@@ -17,8 +41,12 @@ func (h *Handler) RegisterContainerApps(r chi.Router) {
 		r.Get("/", h.ListContainerApps)
 		r.Route("/{name}", func(r chi.Router) {
 			r.Put("/", h.CreateOrUpdateContainerApp)
+			r.Patch("/", h.UpdateContainerApp)
 			r.Get("/", h.GetContainerApp)
 			r.Delete("/", h.DeleteContainerApp)
+
+			r.Post("/getAuthToken", h.GetAuthToken)
+			r.Post("/analyzeCustomDomain", h.AnalyzeCustomDomain)
 
 			r.Route("/revisions", func(r chi.Router) {
 				r.Get("/", h.ListRevisions)
@@ -27,18 +55,27 @@ func (h *Handler) RegisterContainerApps(r chi.Router) {
 				})
 			})
 
+			r.Route("/listSecrets", func(r chi.Router) {
+				r.Get("/", h.ListContainerAppSecrets)
+				r.Post("/", h.CreateContainerAppSecrets)
+			})
+
 			r.Post("/start", h.StartContainerApp)
 			r.Post("/stop", h.StopContainerApp)
 		})
 	})
+
+	r.Route("/subscriptions/{subscriptionId}/providers/Microsoft.App/containerApps", func(r chi.Router) {
+		r.Get("/", h.ListContainerAppsBySubscription)
+	})
 }
 
-func (h *Handler) buildContainerAppResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+func (h *Handler) buildContainerAppResponse(sub, rg, name string, input map[string]any) map[string]any {
 	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/containerApps/" + name
 
-	props, _ := input["properties"].(map[string]interface{})
+	props, _ := input["properties"].(map[string]any)
 	if props == nil {
-		props = map[string]interface{}{}
+		props = map[string]any{}
 	}
 
 	location, _ := input["location"].(string)
@@ -46,13 +83,13 @@ func (h *Handler) buildContainerAppResponse(sub, rg, name string, input map[stri
 		location = "eastus"
 	}
 
-	tags, _ := input["tags"].(map[string]interface{})
+	tags, _ := input["tags"].(map[string]any)
 	if tags == nil {
-		tags = map[string]interface{}{}
+		tags = map[string]any{}
 	}
 
 	environmentID := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/managedEnvironments/default"
-	if envID, ok := props["environmentId"].(string); ok && envID != "" {
+	if envID, ok := props["managedEnvironmentId"].(string); ok && envID != "" {
 		environmentID = envID
 	}
 
@@ -61,19 +98,23 @@ func (h *Handler) buildContainerAppResponse(sub, rg, name string, input map[stri
 		provisioningState = state
 	}
 
-	return map[string]interface{}{
+	fqdn := name + ".hashed.eastus.containerApps.k4apps.io"
+	if inputFqdn, ok := props["fqdn"].(string); ok && inputFqdn != "" {
+		fqdn = inputFqdn
+	}
+
+	response := map[string]any{
 		"id":       id,
 		"name":     name,
 		"type":     "Microsoft.App/containerApps",
 		"location": location,
 		"tags":     tags,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"provisioningState":          provisioningState,
-			"environmentId":              environmentID,
-			"environmentName":            "default",
+			"managedEnvironmentId":       environmentID,
 			"latestRevisionName":         name + "-v1",
-			"latestRevisionFqdn":         name + ".hashed.eastus.containerApps.k4apps.io",
-			"fqdn":                       name + ".hashed.eastus.containerApps.k4apps.io",
+			"latestRevisionFqdn":         fqdn,
+			"fqdn":                       fqdn,
 			"exposedPort":                props["exposedPort"],
 			"customDomainVerificationId": "miniblue",
 			"configuration":              props["configuration"],
@@ -82,6 +123,8 @@ func (h *Handler) buildContainerAppResponse(sub, rg, name string, input map[stri
 			"workloadProfileName":        props["workloadProfileName"],
 		},
 	}
+
+	return sanitizeEmptyStrings(response).(map[string]any)
 }
 
 func (h *Handler) CreateOrUpdateContainerApp(w http.ResponseWriter, r *http.Request) {
@@ -253,4 +296,164 @@ func (h *Handler) StopContainerApp(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(app)
+}
+
+func (h *Handler) UpdateContainerApp(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	app := v.(map[string]interface{})
+
+	if tags, ok := input["tags"].(map[string]interface{}); ok {
+		app["tags"] = tags
+	}
+
+	if props, ok := input["properties"].(map[string]interface{}); ok {
+		existingProps, _ := app["properties"].(map[string]interface{})
+		for k, v := range props {
+			if v != nil {
+				existingProps[k] = v
+			}
+		}
+		app["properties"] = existingProps
+	}
+
+	h.store.Set(h.containerAppKey(sub, rg, name), app)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(app)
+}
+
+func (h *Handler) GetAuthToken(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	_, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	token := map[string]interface{}{
+		"token":            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.miniblue-token",
+		"expiresOn":        "2027-01-01T00:00:00Z",
+		"containerAppName": name,
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(token)
+}
+
+func (h *Handler) AnalyzeCustomDomain(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	_, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	hostname, _ := input["hostname"].(string)
+	if hostname == "" {
+		hostname = name + ".custom.example.com"
+	}
+
+	analysis := map[string]interface{}{
+		"hostname":                       hostname,
+		"isApiHostname":                  true,
+		"isSslEnabled":                   true,
+		"customDomainVerificationResult": "Verified",
+		"certificateNotAfter":            "2027-01-01T00:00:00Z",
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(analysis)
+}
+
+func (h *Handler) ListContainerAppSecrets(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	_, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	app, _ := h.store.Get(h.containerAppKey(sub, rg, name))
+	props, _ := app.(map[string]any)["properties"].(map[string]any)
+	config, _ := props["configuration"].(map[string]any)
+
+	var secrets []map[string]any
+	if secretsVal, ok := config["secrets"].([]any); ok {
+		for _, s := range secretsVal {
+			if secret, ok := s.(map[string]any); ok {
+				secrets = append(secrets, map[string]any{
+					"name":  secret["name"],
+					"value": "***",
+					"type":  secret["type"],
+				})
+			}
+		}
+	}
+
+	if secrets == nil {
+		secrets = []map[string]any{}
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{"value": secrets})
+}
+
+func (h *Handler) ListContainerAppsBySubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("containerapp:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]any{"value": items})
+}
+
+func (h *Handler) CreateContainerAppSecrets(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	_, ok := h.store.Get(h.containerAppKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/containerApps", name)
+		return
+	}
+
+	var secrets []map[string]any = []map[string]any{
+		{"name": "secret1" },
+		{"name": "secret2" },
+	}
+
+	app, _ := h.store.Get(h.containerAppKey(sub, rg, name))
+	props, _ := app.(map[string]any)["properties"].(map[string]any)
+	config, _ := props["configuration"].(map[string]any)
+
+	if config == nil {
+		config = map[string]any{}
+	}
+
+	config["secrets"] = secrets
+	props["configuration"] = config
+	app.(map[string]any)["properties"] = props
+	h.store.Set(h.containerAppKey(sub, rg, name), app)
+
+	json.NewEncoder(w).Encode(map[string]any{"value": secrets})
 }

--- a/internal/services/apps/containerapps.go
+++ b/internal/services/apps/containerapps.go
@@ -437,9 +437,16 @@ func (h *Handler) CreateContainerAppSecrets(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var secrets = []map[string]any{
-		{"name": "secret1" },
-		{"name": "secret2" },
+	var input struct {
+		Properties struct {
+			Secrets []map[string]any `json:"secrets"`
+		} `json:"properties"`
+	}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	secrets := input.Properties.Secrets
+	if secrets == nil {
+		secrets = []map[string]any{}
 	}
 
 	app, _ := h.store.Get(h.containerAppKey(sub, rg, name))
@@ -455,5 +462,14 @@ func (h *Handler) CreateContainerAppSecrets(w http.ResponseWriter, r *http.Reque
 	app.(map[string]any)["properties"] = props
 	h.store.Set(h.containerAppKey(sub, rg, name), app)
 
-	json.NewEncoder(w).Encode(map[string]any{"value": secrets})
+	var response []map[string]any
+	for _, s := range secrets {
+		response = append(response, map[string]any{
+			"name":  s["name"],
+			"value": "***",
+			"type":  s["type"],
+		})
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{"value": response})
 }

--- a/internal/services/apps/containerapps.go
+++ b/internal/services/apps/containerapps.go
@@ -437,7 +437,7 @@ func (h *Handler) CreateContainerAppSecrets(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var secrets []map[string]any = []map[string]any{
+	var secrets = []map[string]any{
 		{"name": "secret1" },
 		{"name": "secret2" },
 	}

--- a/internal/services/apps/environments.go
+++ b/internal/services/apps/environments.go
@@ -1,0 +1,115 @@
+package apps
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+)
+
+func (h *Handler) managedEnvKey(sub, rg, name string) string {
+	return "managedenv:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) RegisterManagedEnvironments(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments", func(r chi.Router) {
+		r.Get("/", h.ListManagedEnvironments)
+		r.Route("/{name}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateManagedEnvironment)
+			r.Get("/", h.GetManagedEnvironment)
+			r.Delete("/", h.DeleteManagedEnvironment)
+		})
+	})
+}
+
+func (h *Handler) buildManagedEnvironmentResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/managedEnvironments/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.App/managedEnvironments",
+		"location": location,
+		"tags":     tags,
+		"properties": map[string]interface{}{
+			"provisioningState": "Succeeded",
+			"deploymentErrors":  "",
+			"externalEndpoints": []interface{}{},
+			"customDomainConfiguration": map[string]interface{}{
+				"customDomainName": "",
+				"dnsSuffix":        "",
+			},
+			"vnetConfiguration":    props["vnetConfiguration"],
+			"appLogsConfiguration": props["appLogsConfiguration"],
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateManagedEnvironment(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	env := h.buildManagedEnvironmentResponse(sub, rg, name, input)
+	k := h.managedEnvKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, env)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(env)
+}
+
+func (h *Handler) GetManagedEnvironment(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.managedEnvKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/managedEnvironments", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteManagedEnvironment(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	if !h.store.Delete(h.managedEnvKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.App/managedEnvironments", name)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) ListManagedEnvironments(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("managedenv:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}

--- a/internal/services/apps/environments.go
+++ b/internal/services/apps/environments.go
@@ -83,7 +83,7 @@ func (h *Handler) CreateOrUpdateManagedEnvironment(w http.ResponseWriter, r *htt
 	if exists {
 		w.WriteHeader(http.StatusOK)
 	} else {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusCreated)
 	}
 	json.NewEncoder(w).Encode(env)
 }

--- a/internal/services/apps/environments.go
+++ b/internal/services/apps/environments.go
@@ -52,8 +52,14 @@ func (h *Handler) buildManagedEnvironmentResponse(sub, rg, name string, input ma
 			"deploymentErrors":  "",
 			"externalEndpoints": []interface{}{},
 			"customDomainConfiguration": map[string]interface{}{
-				"customDomainName": "",
-				"dnsSuffix":        "",
+				"customDomainVerificationId": "",
+				"customDomainName":           "",
+				"dnsSuffix":                  "",
+			},
+			"peerAuthentication": map[string]interface{}{
+				"mtls": map[string]interface{}{
+					"enabled": false,
+				},
 			},
 			"vnetConfiguration":    props["vnetConfiguration"],
 			"appLogsConfiguration": props["appLogsConfiguration"],
@@ -77,7 +83,7 @@ func (h *Handler) CreateOrUpdateManagedEnvironment(w http.ResponseWriter, r *htt
 	if exists {
 		w.WriteHeader(http.StatusOK)
 	} else {
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusOK)
 	}
 	json.NewEncoder(w).Encode(env)
 }

--- a/internal/services/apps/handler.go
+++ b/internal/services/apps/handler.go
@@ -1,0 +1,24 @@
+package apps
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+const (
+	APIVersion = "2024-03-01"
+)
+
+type Handler struct {
+	store *store.Store
+}
+
+func NewHandler(s *store.Store) *Handler {
+	return &Handler{store: s}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	h.RegisterManagedEnvironments(r)
+	h.RegisterContainerApps(r)
+	h.RegisterJobs(r)
+}

--- a/internal/services/apps/jobs.go
+++ b/internal/services/apps/jobs.go
@@ -13,14 +13,23 @@ func (h *Handler) jobKey(sub, rg, name string) string {
 }
 
 func (h *Handler) RegisterJobs(r chi.Router) {
+	r.Get("/subscriptions/{subscriptionId}/providers/Microsoft.App/jobs", h.ListJobsBySubscription)
+
 	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs", func(r chi.Router) {
 		r.Get("/", h.ListJobs)
+		r.Patch("/{name}", h.UpdateJob)
 		r.Route("/{name}", func(r chi.Router) {
 			r.Put("/", h.CreateOrUpdateJob)
 			r.Get("/", h.GetJob)
-			r.Delete("/", h.DeleteJob)
+			r.Get("/detectorProperties/{apiName}", h.ProxyGet)
+			r.Get("/detectors", h.ListDetectors)
+			r.Get("/detectors/{detectorName}", h.GetDetector)
+			r.Post("/listSecrets", h.ListSecrets)
 			r.Post("/start", h.StartJob)
 			r.Post("/stop", h.StopJob)
+			r.Post("/stopExecution", h.StopExecution)
+			r.Post("/stopMultipleExecutions", h.StopMultipleExecutions)
+			r.Delete("/", h.DeleteJob)
 		})
 	})
 }
@@ -167,4 +176,176 @@ func (h *Handler) StopJob(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(job)
+}
+
+func (h *Handler) ListJobsBySubscription(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	items := h.store.ListByPrefix("containerjob:" + sub + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+func (h *Handler) ListSecrets(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	job := v.(map[string]interface{})
+	props, _ := job["properties"].(map[string]interface{})
+	config, _ := props["configuration"].(map[string]interface{})
+	secrets, _ := config["secrets"].([]interface{})
+
+	secretList := []map[string]interface{}{}
+	for _, s := range secrets {
+		if secret, ok := s.(map[string]interface{}); ok {
+			secretList = append(secretList, map[string]interface{}{
+				"name": secret["name"],
+			})
+		}
+	}
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": secretList})
+}
+
+func (h *Handler) UpdateJob(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	var patch map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&patch)
+
+	job := v.(map[string]interface{})
+
+	if tags, ok := patch["tags"].(map[string]interface{}); ok {
+		job["tags"] = tags
+	}
+	if identity, ok := patch["identity"]; ok {
+		job["identity"] = identity
+	}
+	if props, ok := patch["properties"].(map[string]interface{}); ok {
+		jobProps := job["properties"].(map[string]interface{})
+		for k, v := range props {
+			jobProps[k] = v
+		}
+		job["properties"] = jobProps
+	}
+
+	h.store.Set(h.jobKey(sub, rg, name), job)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(job)
+}
+
+func (h *Handler) GetDetector(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+	detectorName := chi.URLParam(r, "detectorName")
+
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/jobs/" + name + "/detectors/" + detectorName
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":   id,
+		"name": detectorName,
+		"type": "Microsoft.App/jobs/detectors",
+		"properties": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"id":          detectorName,
+				"name":        detectorName,
+				"description": "Detector data for Container App Job",
+				"author":      "",
+				"category":    "Availability and Performance",
+				"type":        "Detector",
+				"score":       0,
+			},
+			"status": map[string]interface{}{
+				"statusId": 3,
+			},
+		},
+	})
+}
+
+func (h *Handler) ListDetectors(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/jobs/" + name
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"value": []map[string]interface{}{
+			{
+				"id":   id + "/detectors/containerappjobnetworkIO",
+				"name": "containerappjobnetworkIO",
+				"type": "Microsoft.App/jobs/detectors",
+			},
+		},
+	})
+}
+
+func (h *Handler) ProxyGet(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) StopExecution(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	job := v.(map[string]interface{})
+	props := job["properties"].(map[string]interface{})
+	props["provisioningState"] = "Stopped"
+	job["properties"] = props
+	h.store.Set(h.jobKey(sub, rg, name), job)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(job)
+}
+
+func (h *Handler) StopMultipleExecutions(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	job := v.(map[string]interface{})
+	props := job["properties"].(map[string]interface{})
+	props["provisioningState"] = "Stopped"
+	job["properties"] = props
+	h.store.Set(h.jobKey(sub, rg, name), job)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"value": []interface{}{job},
+	})
 }

--- a/internal/services/apps/jobs.go
+++ b/internal/services/apps/jobs.go
@@ -1,0 +1,170 @@
+package apps
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+)
+
+func (h *Handler) jobKey(sub, rg, name string) string {
+	return "containerjob:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) RegisterJobs(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs", func(r chi.Router) {
+		r.Get("/", h.ListJobs)
+		r.Route("/{name}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateJob)
+			r.Get("/", h.GetJob)
+			r.Delete("/", h.DeleteJob)
+			r.Post("/start", h.StartJob)
+			r.Post("/stop", h.StopJob)
+		})
+	})
+}
+
+func (h *Handler) buildJobResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/jobs/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
+	environmentID := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.App/managedEnvironments/default"
+	if envID, ok := props["environmentId"].(string); ok && envID != "" {
+		environmentID = envID
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.App/jobs",
+		"location": location,
+		"tags":     tags,
+		"properties": map[string]interface{}{
+			"provisioningState":   "Succeeded",
+			"environmentId":       environmentID,
+			"configuration":       props["configuration"],
+			"template":            props["template"],
+			"workloadProfileName": props["workloadProfileName"],
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateJob(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	job := h.buildJobResponse(sub, rg, name, input)
+	k := h.jobKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, job)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(job)
+}
+
+func (h *Handler) GetJob(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteJob(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	if !h.store.Delete(h.jobKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) ListJobs(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("containerjob:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+func (h *Handler) StartJob(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	job, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	props, _ := job["properties"].(map[string]interface{})
+	props["provisioningState"] = "Running"
+	job["properties"] = props
+	h.store.Set(h.jobKey(sub, rg, name), job)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(job)
+}
+
+func (h *Handler) StopJob(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.jobKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	job, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.App/jobs", name)
+		return
+	}
+
+	props, _ := job["properties"].(map[string]interface{})
+	props["provisioningState"] = "Stopped"
+	job["properties"] = props
+	h.store.Set(h.jobKey(sub, rg, name), job)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(job)
+}

--- a/internal/services/sites/config/handler.go
+++ b/internal/services/sites/config/handler.go
@@ -1,0 +1,1067 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+	"github.com/moabukar/miniblue/internal/storageauth"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+type Handler struct {
+	store *store.Store
+}
+
+func NewHandler(store *store.Store) *Handler {
+	return &Handler{store: store}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Route("/config", func(r chi.Router) {
+		r.Get("/web", h.GetConfig)
+		r.Put("/web", h.UpdateConfig)
+		r.Get("/appSettings", h.GetAppSettings)
+		r.Put("/appSettings", h.UpdateAppSettings)
+		r.Get("/appSettings/list", h.ListAppSettings)
+		r.Post("/appSettings/list", h.ListAppSettings)
+		r.Get("/azurestorageaccounts", h.GetAzureStorageAccounts)
+		r.Put("/azurestorageaccounts", h.UpdateAzureStorageAccounts)
+		r.Post("/azurestorageaccounts/list", h.ListAzureStorageAccounts)
+		r.Get("/authsettings", h.GetAuthSettings)
+		r.Put("/authsettings", h.UpdateAuthSettings)
+		r.Get("/authsettings/list", h.ListAuthSettings)
+		r.Put("/authsettings/list", h.UpdateAuthSettings)
+		r.Post("/authsettings/list", h.ListAuthSettings)
+		r.Get("/authsettingsV2", h.GetAuthSettingsV2)
+		r.Put("/authsettingsV2", h.UpdateAuthSettingsV2)
+		r.Get("/authsettingsV2/list", h.ListAuthSettingsV2)
+		r.Post("/authsettingsV2/list", h.ListAuthSettingsV2)
+		r.Get("/backup", h.GetBackupSettings)
+		r.Put("/backup", h.UpdateBackupSettings)
+		r.Get("/logs", h.GetLogsSettings)
+		r.Put("/logs", h.UpdateLogsSettings)
+		r.Get("/metadata", h.GetMetadata)
+		r.Put("/metadata", h.UpdateMetadata)
+		r.Get("/connectionstrings", h.GetConnectionStrings)
+		r.Put("/connectionstrings", h.UpdateConnectionStrings)
+		r.Get("/connectionStrings/list", h.ListConnectionStrings)
+		r.Post("/connectionStrings/list", h.ListConnectionStrings)
+		r.Get("/pushsettings", h.GetPushSettings)
+		r.Put("/pushsettings", h.UpdatePushSettings)
+		r.Get("/slotConfigNames", h.GetSlotConfigNames)
+		r.Put("/slotConfigNames", h.UpdateSlotConfigNames)
+		r.Get("/publishingcredentials/list", h.ListPublishingCredentials)
+		r.Post("/publishingcredentials/list", h.ListPublishingCredentials)
+	})
+}
+
+func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	site, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	props, _ := site["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	siteConfig, _ := props["siteConfig"].(map[string]interface{})
+	if siteConfig == nil {
+		siteConfig = map[string]interface{}{}
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/web",
+		"name":       name + "/config/web",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": siteConfig,
+	})
+}
+
+func (h *Handler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	site, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	props, _ := site["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	var siteConfig map[string]interface{}
+	if input["properties"] != nil {
+		siteConfig, _ = input["properties"].(map[string]interface{})
+	}
+	if siteConfig == nil {
+		siteConfig = map[string]interface{}{}
+	}
+
+	props["siteConfig"] = siteConfig
+	site["properties"] = props
+	h.store.Set(h.siteKey(sub, rg, name), site)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/web",
+		"name":       name + "/config/web",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": siteConfig,
+	})
+}
+
+func (h *Handler) GetAppSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	site, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	props, _ := site["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	appSettings, _ := props["appSettings"].(map[string]interface{})
+	if appSettings == nil {
+		appSettings = map[string]interface{}{}
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/appsettings",
+		"name":       name + "/appsettings",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": appSettings,
+	})
+}
+
+func (h *Handler) ListAppSettings(w http.ResponseWriter, r *http.Request) {
+	h.GetAppSettings(w, r)
+}
+
+func (h *Handler) UpdateAppSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	site, ok := v.(map[string]interface{})
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/config", name)
+		return
+	}
+
+	props, _ := site["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	var appSettings map[string]interface{}
+	if input["properties"] != nil {
+		appSettings, _ = input["properties"].(map[string]interface{})
+	}
+	if appSettings == nil {
+		appSettings = map[string]interface{}{}
+	}
+
+	props["appSettings"] = appSettings
+	site["properties"] = props
+	h.store.Set(h.siteKey(sub, rg, name), site)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/appsettings",
+		"name":       name + "/appsettings",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": appSettings,
+	})
+}
+
+func (h *Handler) GetAzureStorageAccounts(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	storageAccounts := map[string]interface{}{}
+	items := h.store.ListByPrefix(h.azureStorageAccountsKey(sub, rg, name))
+	for _, item := range items {
+		if sa, ok := item.(map[string]interface{}); ok {
+			accountName, _ := sa["accountName"].(string)
+			if accountName != "" {
+				storageAccounts[accountName] = sa
+			}
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/azurestorageaccounts",
+		"name":       name + "/azurestorageaccounts",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": map[string]interface{}{"azurestorageaccounts": storageAccounts},
+	})
+	_ = v
+}
+
+func (h *Handler) ListAzureStorageAccounts(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	storageAccounts := map[string]interface{}{}
+	items := h.store.ListByPrefix(h.azureStorageAccountsKey(sub, rg, name))
+	for _, item := range items {
+		if sa, ok := item.(map[string]interface{}); ok {
+			accountName, _ := sa["accountName"].(string)
+			if accountName != "" {
+				storageAccounts[accountName] = sa
+			}
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/azurestorageaccounts",
+		"name":       name + "/azurestorageaccounts",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": map[string]interface{}{"azurestorageaccounts": storageAccounts},
+	})
+	_ = v
+}
+
+func (h *Handler) UpdateAzureStorageAccounts(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	inputProps, _ := input["properties"].(map[string]interface{})
+	inputStorageAccounts, _ := inputProps["azurestorageaccounts"].(map[string]interface{})
+
+	storageAccounts := map[string]interface{}{}
+	for accountName, config := range inputStorageAccounts {
+		accountConfig, ok := config.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		accountKey := storageauth.DeterministicAccountKey(sub, rg, accountName, "1")
+		connectionString := fmt.Sprintf(
+			"DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=core.windows.net",
+			accountName, accountKey,
+		)
+
+		storageEntry := map[string]interface{}{
+			"value":                connectionString,
+			"type":                 accountConfig["type"],
+			"accountName":          accountName,
+			"accessKey":            accountKey,
+			"blobStorageEndpoint":  fmt.Sprintf("https://%s.blob.core.windows.net/", accountName),
+			"fileStorageEndpoint":  fmt.Sprintf("https://%s.file.core.windows.net/", accountName),
+			"queueStorageEndpoint": fmt.Sprintf("https://%s.queue.core.windows.net/", accountName),
+			"tableStorageEndpoint": fmt.Sprintf("https://%s.table.core.windows.net/", accountName),
+		}
+
+		if mountPath, ok := accountConfig["mountPath"].(string); ok {
+			storageEntry["mountPath"] = mountPath
+		}
+
+		storageAccounts[accountName] = storageEntry
+
+		h.store.Set(h.azureStorageAccountsKey(sub, rg, name)+":"+accountName, storageEntry)
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/azurestorageaccounts",
+		"name":       name + "/azurestorageaccounts",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": map[string]interface{}{"azurestorageaccounts": storageAccounts},
+	})
+	_ = v
+}
+
+func (h *Handler) siteKey(sub, rg, name string) string {
+	return "func:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) azureStorageAccountsKey(sub, rg, site string) string {
+	return "webapp:storage:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) authSettingsKey(sub, rg, site string) string {
+	return "webapp:auth:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetAuthSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	authSettings, ok := h.store.Get(h.authSettingsKey(sub, rg, name))
+	if !ok {
+		authSettings = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/authsettings",
+			"name": name + "/authsettings",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"enabled":                     false,
+				"unauthenticatedClientAction": "RedirectToLoginPage",
+				"tokenStoreEnabled":           false,
+				"allowedExternalRedirectUrls": []interface{}{},
+				"defaultProvider":             "AzureActiveDirectory",
+				"tokenRefreshExtensionHours":  0,
+				"validateNonce":               true,
+				"excludedPaths":               []interface{}{},
+				"requireHttps":                true,
+				"httpApi":                     map[string]interface{}{"enabled": false},
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(authSettings)
+	_ = v
+}
+
+func (h *Handler) ListAuthSettings(w http.ResponseWriter, r *http.Request) {
+	h.GetAuthSettings(w, r)
+}
+
+func (h *Handler) UpdateAuthSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"enabled":                     false,
+			"unauthenticatedClientAction": "RedirectToLoginPage",
+			"tokenStoreEnabled":           false,
+			"allowedExternalRedirectUrls": []interface{}{},
+			"defaultProvider":             "AzureActiveDirectory",
+			"httpApi":                     map[string]interface{}{"enabled": false},
+		}
+	}
+
+	authSettings := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/authsettings",
+		"name":       name + "/authsettings",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.authSettingsKey(sub, rg, name), authSettings)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(authSettings)
+	_ = v
+}
+
+func (h *Handler) backupSettingsKey(sub, rg, site string) string {
+	return "webapp:backup:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetBackupSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	backupSettings, ok := h.store.Get(h.backupSettingsKey(sub, rg, name))
+	if !ok {
+		backupSettings = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/backup",
+			"name": name + "/backup",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"enabled":               false,
+				"backupSchedule":        map[string]interface{}{"frequencyInterval": 0, "frequencyUnit": "Day"},
+				"retentionPeriodInDays": 0,
+				"storageAccountUrl":     "",
+				"databases":             []interface{}{},
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(backupSettings)
+	_ = v
+}
+
+func (h *Handler) UpdateBackupSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"enabled":               false,
+			"backupSchedule":        map[string]interface{}{"frequencyInterval": 0, "frequencyUnit": "Day"},
+			"retentionPeriodInDays": 0,
+			"databases":             []interface{}{},
+		}
+	}
+
+	backupSettings := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/backup",
+		"name":       name + "/backup",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.backupSettingsKey(sub, rg, name), backupSettings)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(backupSettings)
+	_ = v
+}
+
+func (h *Handler) logsSettingsKey(sub, rg, site string) string {
+	return "webapp:logs:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetLogsSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	logsSettings, ok := h.store.Get(h.logsSettingsKey(sub, rg, name))
+	if !ok {
+		logsSettings = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/logs",
+			"name": name + "/logs",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"applicationLogs": map[string]interface{}{
+					"fileSystem":        map[string]interface{}{"level": "Off"},
+					"azureTableStorage": map[string]interface{}{"level": "Off"},
+					"azureBlobStorage":  map[string]interface{}{"level": "Off"},
+				},
+				"httpLogs": map[string]interface{}{
+					"fileSystem":       map[string]interface{}{"enabled": false},
+					"azureBlobStorage": map[string]interface{}{"enabled": false},
+				},
+				"failedRequestsTracingEnabled": false,
+				"detailedErrorMessagesEnabled": false,
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(logsSettings)
+	_ = v
+}
+
+func (h *Handler) UpdateLogsSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"applicationLogs": map[string]interface{}{
+				"fileSystem":        map[string]interface{}{"level": "Off"},
+				"azureTableStorage": map[string]interface{}{"level": "Off"},
+				"azureBlobStorage":  map[string]interface{}{"level": "Off"},
+			},
+			"httpLogs": map[string]interface{}{
+				"fileSystem":       map[string]interface{}{"enabled": false},
+				"azureBlobStorage": map[string]interface{}{"enabled": false},
+			},
+			"failedRequestsTracingEnabled": false,
+			"detailedErrorMessagesEnabled": false,
+		}
+	}
+
+	logsSettings := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/logs",
+		"name":       name + "/logs",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.logsSettingsKey(sub, rg, name), logsSettings)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(logsSettings)
+	_ = v
+}
+
+func (h *Handler) slotConfigNamesKey(sub, rg, site string) string {
+	return "webapp:slotconfignames:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetSlotConfigNames(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	slotConfigNames, ok := h.store.Get(h.slotConfigNamesKey(sub, rg, name))
+	if !ok {
+		slotConfigNames = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/slotConfigNames",
+			"name": name + "/slotConfigNames",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"azureStoragePaths":     nil,
+				"connectionStringNames": []interface{}{},
+				"appSettingNames":       []interface{}{},
+				"handlerMappingNames":   []interface{}{},
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(slotConfigNames)
+	_ = v
+}
+
+func (h *Handler) UpdateSlotConfigNames(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"azureStoragePaths":     nil,
+			"connectionStringNames": []interface{}{},
+			"appSettingNames":       []interface{}{},
+			"handlerMappingNames":   []interface{}{},
+		}
+	}
+
+	slotConfigNames := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/slotConfigNames",
+		"name":       name + "/slotConfigNames",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.slotConfigNamesKey(sub, rg, name), slotConfigNames)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(slotConfigNames)
+	_ = v
+}
+
+func (h *Handler) metadataKey(sub, rg, site string) string {
+	return "webapp:metadata:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetMetadata(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	metadata, ok := h.store.Get(h.metadataKey(sub, rg, name))
+	if !ok {
+		metadata = map[string]interface{}{
+			"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/metadata",
+			"name":       name + "/metadata",
+			"type":       "Microsoft.Web/sites/config",
+			"kind":       nil,
+			"properties": map[string]interface{}{},
+		}
+	}
+
+	json.NewEncoder(w).Encode(metadata)
+	_ = v
+}
+
+func (h *Handler) UpdateMetadata(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	metadata := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/metadata",
+		"name":       name + "/metadata",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.metadataKey(sub, rg, name), metadata)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(metadata)
+	_ = v
+}
+
+func (h *Handler) connectionStringsKey(sub, rg, site string) string {
+	return "webapp:connectionstrings:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetConnectionStrings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	connectionStrings := map[string]interface{}{}
+	items := h.store.ListByPrefix(h.connectionStringsKey(sub, rg, name))
+	for _, item := range items {
+		if cs, ok := item.(map[string]interface{}); ok {
+			csName, _ := cs["name"].(string)
+			if csName != "" {
+				connectionStrings[csName] = cs
+			}
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/connectionstrings",
+		"name":       name + "/connectionstrings",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": map[string]interface{}{"connectionStrings": connectionStrings},
+	})
+	_ = v
+}
+
+func (h *Handler) ListConnectionStrings(w http.ResponseWriter, r *http.Request) {
+	h.GetConnectionStrings(w, r)
+}
+
+func (h *Handler) UpdateConnectionStrings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	inputConnectionStrings, _ := props["connectionStrings"].(map[string]interface{})
+
+	connectionStrings := map[string]interface{}{}
+	for connName, connConfig := range inputConnectionStrings {
+		connInfo, ok := connConfig.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		connectionStrings[connName] = map[string]interface{}{
+			"type":  connInfo["type"],
+			"value": connInfo["value"],
+		}
+		h.store.Set(h.connectionStringsKey(sub, rg, name)+":"+connName, connectionStrings[connName])
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/connectionstrings",
+		"name":       name + "/connectionstrings",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": map[string]interface{}{"connectionStrings": connectionStrings},
+	})
+	_ = v
+}
+
+func (h *Handler) pushSettingsKey(sub, rg, site string) string {
+	return "webapp:pushsettings:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetPushSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	pushSettings, ok := h.store.Get(h.pushSettingsKey(sub, rg, name))
+	if !ok {
+		pushSettings = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/pushsettings",
+			"name": name + "/pushsettings",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"isPushEnabled":     false,
+				"dynamicTagsJson":   "",
+				"tagWhitelistJson":  "",
+				"tagsRequiringAuth": "",
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(pushSettings)
+	_ = v
+}
+
+func (h *Handler) UpdatePushSettings(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"isPushEnabled":     false,
+			"dynamicTagsJson":   "",
+			"tagWhitelistJson":  "",
+			"tagsRequiringAuth": "",
+		}
+	}
+
+	pushSettings := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/pushsettings",
+		"name":       name + "/pushsettings",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.pushSettingsKey(sub, rg, name), pushSettings)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(pushSettings)
+	_ = v
+}
+
+func (h *Handler) authSettingsV2Key(sub, rg, site string) string {
+	return "webapp:authv2:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetAuthSettingsV2(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	authSettingsV2, ok := h.store.Get(h.authSettingsV2Key(sub, rg, name))
+	if !ok {
+		authSettingsV2 = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/authsettingsV2",
+			"name": name + "/authsettingsV2",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"globalValidation": map[string]interface{}{
+					"requireAuthentication":       false,
+					"unauthenticatedClientAction": "AllowAnonymous",
+					"excludedPaths":               []interface{}{},
+				},
+				"httpSettings": map[string]interface{}{
+					"requireHttps": true,
+					"routes":       map[string]interface{}{"apiPrefix": ""},
+					"forwardProxy": map[string]interface{}{"convention": "NoProxy"},
+				},
+				"identityProviders": map[string]interface{}{
+					"azureActiveDirectory": map[string]interface{}{"enabled": false},
+					"facebook":             map[string]interface{}{"enabled": false},
+					"gitHub":               map[string]interface{}{"enabled": false},
+					"google":               map[string]interface{}{"enabled": false},
+					"twitter":              map[string]interface{}{"enabled": false},
+					"apple":                map[string]interface{}{"enabled": false},
+				},
+				"login": map[string]interface{}{
+					"routes": map[string]interface{}{"logoutEndpoint": ""},
+					"tokenStore": map[string]interface{}{
+						"enabled": false,
+					},
+					"cookieExpiration": map[string]interface{}{
+						"convention": "FixedTime",
+					},
+				},
+				"platform": map[string]interface{}{
+					"enabled":        false,
+					"runtimeVersion": "",
+				},
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(authSettingsV2)
+	_ = v
+}
+
+func (h *Handler) ListAuthSettingsV2(w http.ResponseWriter, r *http.Request) {
+	h.GetAuthSettingsV2(w, r)
+}
+
+func (h *Handler) UpdateAuthSettingsV2(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"globalValidation": map[string]interface{}{
+				"requireAuthentication":       false,
+				"unauthenticatedClientAction": "AllowAnonymous",
+				"excludedPaths":               []interface{}{},
+			},
+			"httpSettings": map[string]interface{}{
+				"requireHttps": true,
+				"routes":       map[string]interface{}{"apiPrefix": ""},
+				"forwardProxy": map[string]interface{}{"convention": "NoProxy"},
+			},
+			"identityProviders": map[string]interface{}{
+				"azureActiveDirectory": map[string]interface{}{"enabled": false},
+				"facebook":             map[string]interface{}{"enabled": false},
+				"gitHub":               map[string]interface{}{"enabled": false},
+				"google":               map[string]interface{}{"enabled": false},
+				"twitter":              map[string]interface{}{"enabled": false},
+				"apple":                map[string]interface{}{"enabled": false},
+			},
+			"login": map[string]interface{}{
+				"routes":           map[string]interface{}{"logoutEndpoint": ""},
+				"tokenStore":       map[string]interface{}{"enabled": false},
+				"cookieExpiration": map[string]interface{}{"convention": "FixedTime"},
+			},
+			"platform": map[string]interface{}{
+				"enabled":        false,
+				"runtimeVersion": "",
+			},
+		}
+	}
+
+	authSettingsV2 := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/authsettingsV2",
+		"name":       name + "/authsettingsV2",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.authSettingsV2Key(sub, rg, name), authSettingsV2)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(authSettingsV2)
+	_ = v
+}
+
+func (h *Handler) publishingCredentialsKey(sub, rg, site string) string {
+	return "webapp:publishingcredentials:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) ListPublishingCredentials(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	publishingCredentials, ok := h.store.Get(h.publishingCredentialsKey(sub, rg, name))
+	if !ok {
+		publishingCredentials = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/publishingcredentials",
+			"name": name + "/publishingcredentials",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"publishingUsername":          "$" + name,
+				"publishingPassword":          "",
+				"passwordHash":                nil,
+				"passwordSalt":                nil,
+				"activeDirectoryUserTenantId": nil,
+				"activeDirectoryUserId":       nil,
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(publishingCredentials)
+	_ = v
+}

--- a/internal/services/sites/handler.go
+++ b/internal/services/sites/handler.go
@@ -233,7 +233,6 @@ func (h *Handler) CheckNameAvailability(w http.ResponseWriter, r *http.Request) 
 	if !nameAvailable {
 		resp["reason"] = reason
 		resp["message"] = message
-		w.WriteHeader(http.StatusFound)
 	}
 	json.NewEncoder(w).Encode(resp)
 }

--- a/internal/services/sites/handler.go
+++ b/internal/services/sites/handler.go
@@ -88,8 +88,12 @@ func (h *Handler) Register(r chi.Router) {
 	r.Post("/subscriptions/{subscriptionId}/providers/Microsoft.Web/checknameavailability", h.CheckNameAvailability)
 }
 
-func (h *Handler) siteKey(sub, rg, name string) string {
+func (h *Handler) siteResourceGroupKey(sub, rg, name string) string {
 	return "func:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) siteSubscriptionKey(sub, name string) string {
+	return "func:" + sub + ":" + name
 }
 
 func (h *Handler) buildSiteResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
@@ -142,9 +146,11 @@ func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
 	json.NewDecoder(r.Body).Decode(&input)
 
 	site := h.buildSiteResponse(sub, rg, name, input)
-	k := h.siteKey(sub, rg, name)
-	_, exists := h.store.Get(k)
-	h.store.Set(k, site)
+	kRG := h.siteResourceGroupKey(sub, rg, name)
+	kSub := h.siteSubscriptionKey(sub,name)
+	_, exists := h.store.Get(kRG)
+	h.store.Set(kRG, site)
+	h.store.Set(kSub, site)
 
 	if exists {
 		w.WriteHeader(http.StatusOK)
@@ -159,7 +165,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	v, ok := h.store.Get(h.siteResourceGroupKey(sub, rg, name))
 	if !ok {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return
@@ -172,7 +178,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	if !h.store.Delete(h.siteKey(sub, rg, name)) {
+	if !h.store.Delete(h.siteResourceGroupKey(sub, rg, name)) {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return
 	}
@@ -211,41 +217,11 @@ func (h *Handler) CheckNameAvailability(w http.ResponseWriter, r *http.Request) 
 
 	switch input.Type {
 	case "Microsoft.Web/sites":
-		funcItems := h.store.ListByPrefix("func:" + sub + "::")
-		for _, item := range funcItems {
-			if site, ok := item.(map[string]interface{}); ok {
-				if site["name"] == input.Name {
-					nameAvailable = false
-					reason = "AlreadyExists"
-					message = "The site " + input.Name + " is already in use."
-					break
-				}
-			}
-		}
-		if nameAvailable {
-			webappItems := h.store.ListByPrefix("webapp:" + sub + "::")
-			for _, item := range webappItems {
-				if site, ok := item.(map[string]interface{}); ok {
-					if site["name"] == input.Name {
-						nameAvailable = false
-						reason = "AlreadyExists"
-						message = "The site " + input.Name + " is already in use."
-						break
-					}
-				}
-			}
-		}
-	case "Microsoft.Web/serverFarms":
-		items := h.store.ListByPrefix("serverfarm:" + sub + "::")
-		for _, item := range items {
-			if sf, ok := item.(map[string]interface{}); ok {
-				if sf["name"] == input.Name {
-					nameAvailable = false
-					reason = "AlreadyExists"
-					message = "The server farm " + input.Name + " is already in use."
-					break
-				}
-			}
+		site, _ := h.store.Get("func:" + sub + ":" + input.Name)
+		if site != nil {
+			nameAvailable = false
+			reason = "AlreadyExists"
+			message = "The site " + input.Name + " is already in use."
 		}
 	default:
 		nameAvailable = true
@@ -257,6 +233,7 @@ func (h *Handler) CheckNameAvailability(w http.ResponseWriter, r *http.Request) 
 	if !nameAvailable {
 		resp["reason"] = reason
 		resp["message"] = message
+		w.WriteHeader(http.StatusFound)
 	}
 	json.NewEncoder(w).Encode(resp)
 }
@@ -270,7 +247,7 @@ func (h *Handler) GetBasicPublishingCredentialsPolicies(w http.ResponseWriter, r
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	v, ok := h.store.Get(h.siteResourceGroupKey(sub, rg, name))
 	if !ok {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return
@@ -303,7 +280,7 @@ func (h *Handler) UpdateBasicPublishingCredentialsPolicies(w http.ResponseWriter
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	v, ok := h.store.Get(h.siteResourceGroupKey(sub, rg, name))
 	if !ok {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return
@@ -348,7 +325,7 @@ func (h *Handler) GetScmAllowed(w http.ResponseWriter, r *http.Request) {
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	v, ok := h.store.Get(h.siteResourceGroupKey(sub, rg, name))
 	if !ok {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return
@@ -376,7 +353,7 @@ func (h *Handler) UpdateScmAllowed(w http.ResponseWriter, r *http.Request) {
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	v, ok := h.store.Get(h.siteResourceGroupKey(sub, rg, name))
 	if !ok {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return
@@ -416,7 +393,7 @@ func (h *Handler) GetFtpAllowed(w http.ResponseWriter, r *http.Request) {
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	v, ok := h.store.Get(h.siteResourceGroupKey(sub, rg, name))
 	if !ok {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return
@@ -444,7 +421,7 @@ func (h *Handler) UpdateFtpAllowed(w http.ResponseWriter, r *http.Request) {
 	rg := chi.URLParam(r, "resourceGroupName")
 	name := chi.URLParam(r, "name")
 
-	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	v, ok := h.store.Get(h.siteResourceGroupKey(sub, rg, name))
 	if !ok {
 		azerr.NotFound(w, "Microsoft.Web/sites", name)
 		return

--- a/internal/services/sites/handler.go
+++ b/internal/services/sites/handler.go
@@ -1,0 +1,476 @@
+package sites
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+	"github.com/moabukar/miniblue/internal/services/sites/config"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+const (
+	APIVersion = "2024-03-01"
+)
+
+type Site struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Kind       string            `json:"kind,omitempty"`
+	Properties SiteProps         `json:"properties"`
+	Tags       map[string]string `json:"tags,omitempty"`
+}
+
+type SiteProps struct {
+	ProvisioningState string            `json:"provisioningState"`
+	DefaultHostName   string            `json:"defaultHostName"`
+	HostNames         []string          `json:"hostNames,omitempty"`
+	State             string            `json:"state"`
+	Enabled           bool              `json:"enabled"`
+	ServerFarmID      string            `json:"serverFarmId,omitempty"`
+	SiteConfig        *SiteConfig       `json:"siteConfig,omitempty"`
+	AppSettings       map[string]string `json:"appSettings,omitempty"`
+}
+
+type SiteConfig struct {
+	LinuxFxVersion   string `json:"linuxFxVersion,omitempty"`
+	WindowsFxVersion string `json:"windowsFxVersion,omitempty"`
+	FtpsState        string `json:"ftpsState,omitempty"`
+	MinTlsVersion    string `json:"minTlsVersion,omitempty"`
+	AlwaysOn         bool   `json:"alwaysOn,omitempty"`
+}
+
+type Handler struct {
+	store *store.Store
+}
+
+func NewHandler(s *store.Store) *Handler {
+	return &Handler{store: s}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites", func(r chi.Router) {
+		r.Get("/", h.List)
+		r.Route("/{name}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdate)
+			r.Get("/", h.Get)
+			r.Delete("/", h.Delete)
+
+			config.NewHandler(h.store).Register(r)
+
+			r.Route("/basicPublishingCredentialsPolicies", func(r chi.Router) {
+				r.Get("/", h.GetBasicPublishingCredentialsPolicies)
+				r.Route("/ftp", func (r chi.Router) {
+					r.Get("/", h.GetFtpAllowed)
+					r.Put("/", h.UpdateFtpAllowed)
+				})
+				r.Route("/scm", func (r chi.Router) {
+					r.Get("/", h.GetScmAllowed)
+					r.Put("/", h.UpdateScmAllowed)
+				})
+			})
+
+			r.Route("/slots", func(r chi.Router) {
+				r.Get("/", h.ListSlots)
+				r.Route("/{slotName}", func(r chi.Router) {
+					r.Put("/", h.CreateOrUpdateSlot)
+					r.Get("/", h.GetSlot)
+					r.Delete("/", h.DeleteSlot)
+				})
+			})
+		})
+	})
+
+	h.RegisterServerFarms(r)
+	r.Post("/subscriptions/{subscriptionId}/providers/Microsoft.Web/checknameavailability", h.CheckNameAvailability)
+}
+
+func (h *Handler) siteKey(sub, rg, name string) string {
+	return "func:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) buildSiteResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	kind, _ := input["kind"].(string)
+	if kind == "" {
+		kind = "functionapp"
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.Web/sites",
+		"kind":     kind,
+		"location": location,
+		"tags":     tags,
+		"properties": map[string]interface{}{
+			"provisioningState": "Succeeded",
+			"defaultHostName":   name + ".azurewebsites.net",
+			"hostNames":         []interface{}{name + ".azurewebsites.net"},
+			"state":             "Running",
+			"enabled":           true,
+			"serverFarmId":      props["serverFarmId"],
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	site := h.buildSiteResponse(sub, rg, name, input)
+	k := h.siteKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, site)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	json.NewEncoder(w).Encode(site)
+}
+
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	if !h.store.Delete(h.siteKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	funcItems := h.store.ListByPrefix("func:" + sub + ":" + rg + ":")
+	webappItems := h.store.ListByPrefix("webapp:" + sub + ":" + rg + ":")
+	allItems := append(funcItems, webappItems...)
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": allItems})
+}
+
+func (h *Handler) CheckNameAvailability(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    "InvalidRequestBody",
+				"message": "Could not parse request body.",
+			},
+		})
+		return
+	}
+
+	sub := chi.URLParam(r, "subscriptionId")
+	nameAvailable := true
+	reason := ""
+	message := ""
+
+	switch input.Type {
+	case "Microsoft.Web/sites":
+		funcItems := h.store.ListByPrefix("func:" + sub + "::")
+		for _, item := range funcItems {
+			if site, ok := item.(map[string]interface{}); ok {
+				if site["name"] == input.Name {
+					nameAvailable = false
+					reason = "AlreadyExists"
+					message = "The site " + input.Name + " is already in use."
+					break
+				}
+			}
+		}
+		if nameAvailable {
+			webappItems := h.store.ListByPrefix("webapp:" + sub + "::")
+			for _, item := range webappItems {
+				if site, ok := item.(map[string]interface{}); ok {
+					if site["name"] == input.Name {
+						nameAvailable = false
+						reason = "AlreadyExists"
+						message = "The site " + input.Name + " is already in use."
+						break
+					}
+				}
+			}
+		}
+	case "Microsoft.Web/serverFarms":
+		items := h.store.ListByPrefix("serverfarm:" + sub + "::")
+		for _, item := range items {
+			if sf, ok := item.(map[string]interface{}); ok {
+				if sf["name"] == input.Name {
+					nameAvailable = false
+					reason = "AlreadyExists"
+					message = "The server farm " + input.Name + " is already in use."
+					break
+				}
+			}
+		}
+	default:
+		nameAvailable = true
+	}
+
+	resp := map[string]interface{}{
+		"nameAvailable": nameAvailable,
+	}
+	if !nameAvailable {
+		resp["reason"] = reason
+		resp["message"] = message
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (h *Handler) basicPublishingCredentialsPoliciesKey(sub, rg, site string) string {
+	return "webapp:basicpublishingcredentialspolicies:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetBasicPublishingCredentialsPolicies(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	policies, ok := h.store.Get(h.basicPublishingCredentialsPoliciesKey(sub, rg, name))
+	if !ok {
+		policies = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/basicPublishingCredentialsPolicies",
+			"name": name + "/basicPublishingCredentialsPolicies",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"scm": map[string]interface{}{
+					"allow": true,
+				},
+				"ftp": map[string]interface{}{
+					"allow": true,
+				},
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(policies)
+	_ = v
+}
+
+func (h *Handler) UpdateBasicPublishingCredentialsPolicies(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"scm": map[string]interface{}{
+				"allow": true,
+			},
+			"ftp": map[string]interface{}{
+				"allow": true,
+			},
+		}
+	}
+
+	policies := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/basicPublishingCredentialsPolicies",
+		"name":       name + "/basicPublishingCredentialsPolicies",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.basicPublishingCredentialsPoliciesKey(sub, rg, name), policies)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(policies)
+	_ = v
+}
+
+func (h *Handler) scmAllowedKey(sub, rg, site string) string {
+	return "webapp:scmallowed:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetScmAllowed(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	scmAllowed, ok := h.store.Get(h.scmAllowedKey(sub, rg, name))
+	if !ok {
+		scmAllowed = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/basicPublishingCredentialsPolicies/scm",
+			"name": name + "/scm",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"allow": true,
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(scmAllowed)
+	_ = v
+}
+
+func (h *Handler) UpdateScmAllowed(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"allow": true,
+		}
+	}
+
+	scmAllowed := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/basicPublishingCredentialsPolicies/scm",
+		"name":       name + "/scm",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.scmAllowedKey(sub, rg, name), scmAllowed)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(scmAllowed)
+	_ = v
+}
+
+func (h *Handler) ftpAllowedKey(sub, rg, site string) string {
+	return "webapp:ftpassigned:" + sub + ":" + rg + ":" + site
+}
+
+func (h *Handler) GetFtpAllowed(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	ftpAllowed, ok := h.store.Get(h.ftpAllowedKey(sub, rg, name))
+	if !ok {
+		ftpAllowed = map[string]interface{}{
+			"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/basicPublishingCredentialsPolicies/ftp",
+			"name": name + "/ftp",
+			"type": "Microsoft.Web/sites/config",
+			"kind": nil,
+			"properties": map[string]interface{}{
+				"allow": true,
+			},
+		}
+	}
+
+	json.NewEncoder(w).Encode(ftpAllowed)
+	_ = v
+}
+
+func (h *Handler) UpdateFtpAllowed(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.siteKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites", name)
+		return
+	}
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{
+			"allow": true,
+		}
+	}
+
+	ftpAllowed := map[string]interface{}{
+		"id":         "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name + "/config/basicPublishingCredentialsPolicies/ftp",
+		"name":       name + "/ftp",
+		"type":       "Microsoft.Web/sites/config",
+		"kind":       nil,
+		"properties": props,
+	}
+
+	h.store.Set(h.ftpAllowedKey(sub, rg, name), ftpAllowed)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(ftpAllowed)
+	_ = v
+}

--- a/internal/services/sites/serverfarms.go
+++ b/internal/services/sites/serverfarms.go
@@ -1,0 +1,156 @@
+package sites
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+)
+
+type ServerFarm struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Kind       string            `json:"kind,omitempty"`
+	Properties ServerFarmProps   `json:"properties"`
+	Tags       map[string]string `json:"tags,omitempty"`
+}
+
+type ServerFarmProps struct {
+	ProvisioningState string `json:"provisioningState"`
+	WorkerSize        string `json:"workerSize,omitempty"`
+	WorkerSizeID      int    `json:"workerSizeId,omitempty"`
+	NumberOfWorkers   int    `json:"numberOfWorkers,omitempty"`
+	SkuName           string `json:"skuName,omitempty"`
+	SkuTier           string `json:"skuTier,omitempty"`
+	OSType            string `json:"ostype,omitempty"`
+}
+
+func (h *Handler) serverFarmKey(sub, rg, name string) string {
+	return "serverfarm:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) RegisterServerFarms(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverFarms", func(r chi.Router) {
+		r.Get("/", h.ListServerFarms)
+		r.Route("/{name}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdateServerFarm)
+			r.Get("/", h.GetServerFarm)
+			r.Delete("/", h.DeleteServerFarm)
+		})
+	})
+}
+
+func (h *Handler) buildServerFarmResponse(sub, rg, name string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/serverFarms/" + name
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	kind, _ := input["kind"].(string)
+	if kind == "" {
+		kind = "linux"
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
+	skuName, _ := props["skuName"].(string)
+	skuTier := "Premium"
+	if skuName != "" {
+		switch {
+		case skuName[0] >= 'F' && skuName[0] <= 'P':
+			skuTier = "Premium"
+		case skuName[0] >= 'B' && skuName[0] <= 'D':
+			skuTier = "Basic"
+		case skuName[0] >= 'S':
+			skuTier = "Standard"
+		}
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     name,
+		"type":     "Microsoft.Web/serverFarms",
+		"kind":     kind,
+		"location": location,
+		"tags":     tags,
+		"properties": map[string]interface{}{
+			"provisioningState": "Succeeded",
+			"workerSize":        props["workerSize"],
+			"workerSizeId":      props["workerSizeId"],
+			"numberOfWorkers":   props["numberOfWorkers"],
+			"reserved":          kind == "linux",
+			"isXenon":           false,
+			"hyperV":            false,
+			"status":            "Ready",
+			"subscription":      sub,
+			"skuName":           skuName,
+			"skuTier":           skuTier,
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateServerFarm(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	sf := h.buildServerFarmResponse(sub, rg, name, input)
+	k := h.serverFarmKey(sub, rg, name)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, sf)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	json.NewEncoder(w).Encode(sf)
+}
+
+func (h *Handler) GetServerFarm(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	v, ok := h.store.Get(h.serverFarmKey(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/serverFarms", name)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteServerFarm(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+
+	if !h.store.Delete(h.serverFarmKey(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Web/serverFarms", name)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) ListServerFarms(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("serverfarm:" + sub + ":" + rg + ":")
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}

--- a/internal/services/sites/serverfarms.go
+++ b/internal/services/sites/serverfarms.go
@@ -151,6 +151,6 @@ func (h *Handler) DeleteServerFarm(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListServerFarms(w http.ResponseWriter, r *http.Request) {
 	sub := chi.URLParam(r, "subscriptionId")
 	rg := chi.URLParam(r, "resourceGroupName")
-	items := h.store.ListByPrefix("serverfarm:" + sub + ":" + rg + ":")
+	items := h.store.ListByPrefix("serverfarm:" + sub + ":" + rg)
 	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
 }

--- a/internal/services/sites/serverfarms.go
+++ b/internal/services/sites/serverfarms.go
@@ -67,15 +67,23 @@ func (h *Handler) buildServerFarmResponse(sub, rg, name string, input map[string
 	}
 
 	skuName, _ := props["skuName"].(string)
-	skuTier := "Premium"
+	skuTier := "Free"
 	if skuName != "" {
-		switch {
-		case skuName[0] >= 'F' && skuName[0] <= 'P':
-			skuTier = "Premium"
-		case skuName[0] >= 'B' && skuName[0] <= 'D':
+		switch skuName[0] {
+		case 'F', 'f':
+			skuTier = "Free"
+		case 'D', 'd':
+			skuTier = "Shared"
+		case 'B', 'b':
 			skuTier = "Basic"
-		case skuName[0] >= 'S':
+		case 'S', 's':
 			skuTier = "Standard"
+		case 'P', 'p':
+			skuTier = "Premium"
+		case 'I', 'i':
+			skuTier = "Isolated"
+		case 'Y', 'y':
+			skuTier = "Dynamic"
 		}
 	}
 

--- a/internal/services/sites/slots.go
+++ b/internal/services/sites/slots.go
@@ -1,0 +1,106 @@
+package sites
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+)
+
+func (h *Handler) slotKey(sub, rg, site, slot string) string {
+	return "slot:" + sub + ":" + rg + ":" + site + ":" + slot
+}
+
+func (h *Handler) ListSlots(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "name")
+	items := h.store.ListByPrefix(h.slotKey(sub, rg, name, ""))
+	json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+func (h *Handler) buildSlotResponse(sub, rg, siteName, slotName string, input map[string]interface{}) map[string]interface{} {
+	id := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + siteName + "/slots/" + slotName
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+
+	location, _ := input["location"].(string)
+	if location == "" {
+		location = "eastus"
+	}
+
+	tags, _ := input["tags"].(map[string]interface{})
+	if tags == nil {
+		tags = map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"id":       id,
+		"name":     siteName + "/" + slotName,
+		"type":     "Microsoft.Web/sites/slots",
+		"kind":     input["kind"],
+		"location": location,
+		"tags":     tags,
+		"properties": map[string]interface{}{
+			"provisioningState": "Succeeded",
+			"defaultHostName":   slotName + "-" + siteName + ".azurewebsites.net",
+			"hostNames":         []interface{}{slotName + "-" + siteName + ".azurewebsites.net"},
+			"state":             "Running",
+			"enabled":           true,
+			"serverFarmId":      props["serverFarmId"],
+		},
+	}
+}
+
+func (h *Handler) CreateOrUpdateSlot(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	siteName := chi.URLParam(r, "name")
+	slotName := chi.URLParam(r, "slotName")
+
+	var input map[string]interface{}
+	json.NewDecoder(r.Body).Decode(&input)
+
+	slot := h.buildSlotResponse(sub, rg, siteName, slotName, input)
+	k := h.slotKey(sub, rg, siteName, slotName)
+	_, exists := h.store.Get(k)
+	h.store.Set(k, slot)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	json.NewEncoder(w).Encode(slot)
+}
+
+func (h *Handler) GetSlot(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	siteName := chi.URLParam(r, "name")
+	slotName := chi.URLParam(r, "slotName")
+
+	v, ok := h.store.Get(h.slotKey(sub, rg, siteName, slotName))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Web/sites/slots", slotName)
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) DeleteSlot(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	siteName := chi.URLParam(r, "name")
+	slotName := chi.URLParam(r, "slotName")
+
+	if !h.store.Delete(h.slotKey(sub, rg, siteName, slotName)) {
+		azerr.NotFound(w, "Microsoft.Web/sites/slots", slotName)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -163,7 +163,7 @@ func TestManagedEnvironmentCRUD(t *testing.T) {
 
 	resp := doRequest(t, "PUT", base+"/myenv"+av, `{"location":"eastus"}`)
 	defer resp.Body.Close()
-	expectStatus(t, resp, 200)
+	expectStatus(t, resp, 201)
 
 	m := decodeJSON(t, resp)
 	props := m["properties"].(map[string]interface{})

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -154,3 +154,53 @@ func TestContainerAppListBySubscription(t *testing.T) {
 		t.Fatalf("expected 2 items, got %d", len(items))
 	}
 }
+
+func TestManagedEnvironmentCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/myenv"+av, `{"location":"eastus"}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded")
+	}
+	if m["id"] != "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/myenv" {
+		t.Fatalf("unexpected id: %v", m["id"])
+	}
+
+	resp = doRequest(t, "GET", base+"/myenv"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	doRequest(t, "DELETE", base+"/myenv"+av, "").Body.Close()
+	resp = doRequest(t, "GET", base+"/myenv"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 404)
+}
+
+func TestContainerAppWithEnvironment(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	envBase := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments"
+	appBase := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", envBase+"/myenv"+av, `{"location":"eastus"}`).Body.Close()
+
+	resp := doRequest(t, "PUT", appBase+"/myapp"+av, `{"location":"eastus","properties":{"environmentId":"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/myenv"}}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	props := m["properties"].(map[string]interface{})
+	envID, _ := props["managedEnvironmentId"].(string)
+	if envID == "" {
+		t.Fatalf("expected managedEnvironmentId in response")
+	}
+}

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -1,0 +1,156 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestContainerAppCRUD(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+
+	resp := doRequest(t, "PUT", base+"/myapp"+av,
+		`{"location":"eastus"}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 201)
+
+	m := decodeJSON(t, resp)
+	props := m["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Succeeded" {
+		t.Fatalf("expected provisioningState=Succeeded")
+	}
+	if m["id"] != "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps/myapp" {
+		t.Fatalf("unexpected id: %v", m["id"])
+	}
+
+	resp = doRequest(t, "PUT", base+"/myapp"+av, `{"location":"eastus"}`)
+	resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	resp = doRequest(t, "GET", base+"/myapp"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+	m = decodeJSON(t, resp)
+	if m["name"] != "myapp" {
+		t.Fatalf("expected name=myapp")
+	}
+
+	doRequest(t, "DELETE", base+"/myapp"+av, "").Body.Close()
+	resp = doRequest(t, "GET", base+"/myapp"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 404)
+}
+
+func TestContainerAppList(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/app1"+av, `{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", base+"/app2"+av, `{"location":"eastus"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	items := m["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestContainerAppStartStop(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/myapp"+av, `{"location":"eastus"}`).Body.Close()
+
+	resp := doRequest(t, "POST", base+"/myapp/start"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	resp = doRequest(t, "POST", base+"/myapp/stop"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+}
+
+func TestContainerAppRevisions(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/myapp"+av, `{"location":"eastus"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+"/myapp/revisions"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	items := m["value"].([]interface{})
+	if len(items) == 0 {
+		t.Fatalf("expected at least 1 revision")
+	}
+}
+
+func TestContainerAppGetAuthToken(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/myapp"+av, `{"location":"eastus"}`).Body.Close()
+
+	resp := doRequest(t, "POST", base+"/myapp/getAuthToken"+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	if m["token"] == nil {
+		t.Fatalf("expected token")
+	}
+}
+
+func TestContainerAppAnalyzeCustomDomain(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+
+	doRequest(t, "PUT", base+"/myapp"+av, `{"location":"eastus"}`).Body.Close()
+
+	resp := doRequest(t, "POST", base+"/myapp/analyzeCustomDomain"+av, `{"hostname":"app.example.com"}`)
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	if m["hostname"] != "app.example.com" {
+		t.Fatalf("expected hostname=app.example.com")
+	}
+}
+
+func TestContainerAppListBySubscription(t *testing.T) {
+	ts := setupServer()
+	defer ts.Close()
+	base := ts.URL + "/subscriptions/sub1/providers/Microsoft.App/containerApps"
+	av := "?api-version=2023-09-01"
+	rgBase := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps"
+
+	doRequest(t, "PUT", rgBase+"/app1"+av, `{"location":"eastus"}`).Body.Close()
+	doRequest(t, "PUT", rgBase+"/app2"+av, `{"location":"eastus"}`).Body.Close()
+
+	resp := doRequest(t, "GET", base+av, "")
+	defer resp.Body.Close()
+	expectStatus(t, resp, 200)
+
+	m := decodeJSON(t, resp)
+	items := m["value"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+}

--- a/tests/functions_test.go
+++ b/tests/functions_test.go
@@ -14,7 +14,7 @@ func TestFunctionAppCRUD(t *testing.T) {
 	resp := doRequest(t, "PUT", base+"/myfunc"+av,
 		`{"location":"eastus"}`)
 	defer resp.Body.Close()
-	expectStatus(t, resp, 201)
+	expectStatus(t, resp, 200)
 
 	m := decodeJSON(t, resp)
 	props := m["properties"].(map[string]interface{})


### PR DESCRIPTION
## What does this PR do?

This PR intends to add App Service and Web Apps as an additional service

## Type of change

- [ ] Bug fix
- [X] New Azure service emulation
- [X] Improvement to existing service
- [ ] Documentation
- [ ] Other

## Azure service(s) affected

- [ ] Resource Groups
- [ ] Blob Storage
- [ ] Table Storage
- [ ] Queue Storage
- [ ] Storage Accounts
- [ ] Key Vault
- [ ] Cosmos DB
- [ ] Service Bus
- [X] Functions
- [ ] Virtual Networks
- [ ] DNS Zones
- [ ] Public IP Addresses
- [ ] Network Security Groups
- [ ] Load Balancer
- [ ] Application Gateway
- [ ] Container Registry
- [ ] Event Grid
- [X] App Configuration
- [ ] Managed Identity
- [ ] Auth / Metadata
- [X] App Service / Web App
- [X] Container App
- [ ] None (infra/docs)

## Testing

- [x] Tested locally with curl
- [x] Tested with azlocal CLI
- [x] Tested with Docker build
- [X] Added/updated tests

## Checklist

- [X] Code compiles (`go build ./...`)
- [X] No new linting errors
- [ ] Updated README if needed
