### PR TITLE
fix: fall through to generate new cert when existing certs are missing, invalid, or expired

### DIFF
--- a/cmd/miniblue/main.go
+++ b/cmd/miniblue/main.go
@@ -210,19 +210,19 @@ func generateAndSaveCert(dir string) (tls.Certificate, []byte, error) {
 							log.Printf("Reusing existing certificate (expires %s)", leaf.NotAfter.Format("2006-01-02"))
 							return tlsCert, certPEM, nil
 						} else {
-							return tls.Certificate{}, nil, fmt.Errorf("failed to load certificate, expired: %w", err)
+							log.Printf("existing certificate expired, generating new one")
 						}
 					} else {
-						return tls.Certificate{}, nil, fmt.Errorf("failed to parse certificate: %w", err)
+						log.Printf("failed to parse existing certificate: %v, generating new one", err)
 					}
 				} else {
-					return tls.Certificate{}, nil, fmt.Errorf("failed to load existing certificate: %w", err)
+					log.Printf("failed to load existing key pair: %v, generating new one", err)
 				}
 			} else {
-				return tls.Certificate{}, nil, fmt.Errorf("failed to load key: %w", err)
+				log.Printf("key file not found or unreadable: %v, generating new certificate", err)
 			}
 		} else {
-			return tls.Certificate{}, nil, fmt.Errorf("failed to load certificate: %w", err)
+			log.Printf("cert file not found or unreadable: %v, generating new certificate", err)
 		}
 	} else if os.IsNotExist(err) {
 		log.Printf("cert directory does not exist, creating ...")


### PR DESCRIPTION
## Problem

When running miniblue in a Docker container, `generateAndSaveCert()` fails fatally if the cert directory exists but `cert.pem`/`key.pem` are missing, corrupted, or expired.

This happens because every failure branch in the nested `if` chain returns an error instead of falling through to the certificate generation code. The only path that reaches cert generation is when the directory itself doesn't exist (`os.IsNotExist`).

**Reproduction (Docker on Windows or any OS):**
```
docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
# Fails with: Failed to load / generate cert: failed to load certificate: open /.miniblue/cert.pem: no such file or directory
```

Even mounting a volume doesn't help because the directory then exists but is empty:
```
docker run -p 4566:4566 -p 4567:4567 -v miniblue-certs:/.miniblue moabukar/miniblue:latest
# Same error
```

## Root Cause

In `cmd/miniblue/main.go`, the `generateAndSaveCert` function has this logic:

1. If dir exists → try to load cert → if **any step fails**, return error (BUG)
2. If dir doesn't exist → create it → fall through to generate cert (OK)

All the error branches in case 1 should fall through to generate a new certificate instead of returning fatal errors.

## Fix

Replace `return error` with `log.Printf` warning + fall through in all cases where existing certs can't be reused (missing files, parse errors, expired certs). The only early return is the happy path where a valid, non-expired cert is successfully loaded.

## Testing

Verified the fix allows `docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest` to start successfully and generate certificates on first run.