### PR TITLE
fix(ci,docker): build E2E image from source and provide writable HOME for nonroot user

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,18 +13,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Build miniblue image from PR
+        run: docker build -t miniblue:pr .
+
       - name: Start miniblue
         run: |
-          docker run -d --name miniblue -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
+          docker run -d --name miniblue -p 4566:4566 -p 4567:4567 miniblue:pr
           echo "Waiting for miniblue..."
           for i in $(seq 1 30); do
-            if curl -s http://localhost:4566/health > /dev/null 2>&1; then
+            if curl -fs http://localhost:4566/health > /dev/null 2>&1; then
               echo "miniblue is ready"
               break
             fi
             sleep 1
           done
-          curl -s http://localhost:4566/health | python3 -m json.tool
+          if ! curl -fsS http://localhost:4566/health | python3 -m json.tool; then
+            echo "miniblue did not become healthy; container logs:"
+            docker logs miniblue || true
+            exit 1
+          fi
 
       - name: Test health
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,17 @@ ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X github.com/moabukar/miniblue/internal/server.Version=${VERSION}" -o /miniblue ./cmd/miniblue
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /azlocal ./cmd/azlocal
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /healthcheck ./cmd/healthcheck
+RUN mkdir -p /home/nonroot
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /miniblue /miniblue
 COPY --from=builder /azlocal /azlocal
 COPY --from=builder /healthcheck /healthcheck
+COPY --from=builder --chown=65534:65534 /home/nonroot /home/nonroot
 EXPOSE 4566 4567
 ENV PORT=4566
+ENV HOME=/home/nonroot
 USER 65534
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["/healthcheck"]
 ENTRYPOINT ["/miniblue"]


### PR DESCRIPTION
## Summary

- E2E workflow was pulling `moabukar/miniblue:latest` from Docker Hub instead of building from the PR source. The test result was therefore independent of the PR diff — Renovate dep bumps (#106, #107, #108) could never influence it, and a real regression introduced in a PR would silently pass here.
- That is also why every open PR currently has a red E2E check: the published `:latest` is hitting the cert-load bug fixed by #109 (container exits before serving HTTP, `curl` returns empty, `python3 -m json.tool` errors with `Expecting value: line 1 column 1`).

This PR builds the image from the PR's `Dockerfile`, and replaces the silent `curl -s | json.tool` with `curl -fsS` plus a `docker logs miniblue` dump on failure, so future startup crashes fail with a useful message instead of the cryptic JSON parse error.

After this lands and #109 is merged, the Renovate PRs should go green on rebase.