### PR TITLE
ci(aks): add full-image job that exercises in-container real backend

### DIFF
--- a/.github/workflows/aks-e2e.yml
+++ b/.github/workflows/aks-e2e.yml
@@ -22,6 +22,60 @@ on:
   workflow_dispatch:
 
 jobs:
+  full-image:
+    name: AKS real backend via :full Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build :full image
+        run: docker build --target=full -t miniblue:full .
+
+      - name: Pre-pull k3s image on host
+        run: docker pull rancher/k3s:v1.30.14-k3s1
+
+      - name: Run miniblue:full with mounted socket
+        run: |
+          docker run -d --name mb-full \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -p 4566:4566 -p 4567:4567 \
+            -e AKS_BACKEND=k3s \
+            miniblue:full
+          for i in $(seq 1 20); do
+            if curl -fs http://localhost:4566/health > /dev/null; then echo "ready ${i}s"; break; fi
+            sleep 1
+          done
+          docker logs mb-full 2>&1 | grep -iE "aks|aci" | head -3
+
+      - name: Create cluster from in-container miniblue
+        run: |
+          curl -fsS -X PUT 'http://localhost:4566/subscriptions/s1/resourcegroups/full-rg' \
+            -H 'Content-Type: application/json' -d '{"location":"eastus"}' > /dev/null
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X PUT \
+            'http://localhost:4566/subscriptions/s1/resourceGroups/full-rg/providers/Microsoft.ContainerService/managedClusters/k1' \
+            -H 'Content-Type: application/json' \
+            -d '{"location":"eastus","identity":{"type":"SystemAssigned"},"properties":{"dnsPrefix":"k1"}}')
+          [ "$STATUS" = "201" ] && echo "OK" || (echo "FAIL: $STATUS"; docker logs mb-full | tail -50; exit 1)
+
+      - name: Verify k3s container alive on host
+        run: |
+          docker ps --filter name=miniblue-aks- --format '{{.Names}} {{.Ports}}'
+          docker ps --filter name=miniblue-aks- -q | grep -q . || (echo "no k3s container spawned"; exit 1)
+
+      - name: kubectl from host hits the spawned k3s
+        run: |
+          curl -fsS -X POST 'http://localhost:4566/subscriptions/s1/resourceGroups/full-rg/providers/Microsoft.ContainerService/managedClusters/k1/listClusterAdminCredential' \
+            -H 'Content-Type: application/json' -d '{}' \
+            | python3 -c "import json,sys,base64; sys.stdout.write(base64.b64decode(json.load(sys.stdin)['kubeconfigs'][0]['value']).decode())" > /tmp/kfg
+          KUBECONFIG=/tmp/kfg kubectl get nodes -o wide
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f mb-full || true
+          docker ps -aq --filter name=miniblue-aks- | xargs -r docker rm -f
+
   real-backend:
     name: AKS real backend (k3s in DinD)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Catches regressions in the Dockerfile `full` target, alpine base, or docker-cli install that would break running miniblue in a container with `AKS_BACKEND=k3s`. Existing CI only tests the binary path.