### PR TITLE
feat(deployments): Microsoft.Resources/deployments Phase 1 (Bicep + ARM templates)

### DIFF
--- a/examples/bicep/README.md
+++ b/examples/bicep/README.md
@@ -1,0 +1,54 @@
+# Bicep / ARM template example
+
+Deploy a Bicep file against miniblue end to end.
+
+## Prerequisites
+
+```bash
+./bin/miniblue
+export SSL_CERT_FILE=~/.miniblue/cert.pem  # or run scripts/trust-cert.sh once
+```
+
+## Apply
+
+```bash
+azlocal group create --name bicep-rg --location eastus
+
+az deployment group create \
+  --resource-group bicep-rg \
+  --template-file main.bicep \
+  --parameters saName=mystorage clusterName=mycluster
+```
+
+`az` builds the Bicep file to ARM JSON and PUTs it to miniblue's `Microsoft.Resources/deployments` endpoint, which dispatches each resource to its handler.
+
+Verify:
+
+```bash
+azlocal storage account show --resource-group bicep-rg --name mystorage
+azlocal aks list --resource-group bicep-rg
+```
+
+## Phase 1 scope
+
+Supported in this release:
+
+- PUT/GET/DELETE/List on `Microsoft.Resources/deployments`
+- Linear iteration of `template.resources` in declaration order
+- `[parameters('name')]` substitution (with `defaultValue` fallback)
+- `[variables('name')]` substitution
+- Each resource dispatched as a synthetic PUT against its existing handler
+- `provisioningState` of `Succeeded` or `Failed`; per-resource error message on failure
+
+Not supported yet (open follow-up issue #74):
+
+- `[concat(...)]`, `[resourceId(...)]`, `[reference(...)]`, and other template functions
+- `copy` loops
+- `condition` on resources
+- Nested templates and module references
+- `outputs` evaluation
+- `dependsOn` ordering (resources are applied in declaration order)
+- Subscription-scope, management-group-scope, and tenant-scope deployments
+- `What-If` and `Validate` operations
+
+For Bicep files that use unsupported constructs, the deployment endpoint will pass them through to the handler unchanged (which usually means the resource gets a literal expression string in the field). Use literals or pre-flattened ARM JSON in the meantime.

--- a/examples/bicep/main.bicep
+++ b/examples/bicep/main.bicep
@@ -1,0 +1,35 @@
+// Minimal Bicep example deployable against miniblue.
+//
+//   az deployment group create \
+//     --resource-group bicep-rg \
+//     --template-file main.bicep \
+//     --parameters saName=mystorage clusterName=mycluster
+//
+// Bicep transpiles to ARM JSON which miniblue's
+// Microsoft.Resources/deployments endpoint applies by dispatching each
+// resource to its existing handler.
+
+param location string = 'eastus'
+param saName string
+param clusterName string
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: saName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {}
+}
+
+resource aks 'Microsoft.ContainerService/managedClusters@2023-09-01' = {
+  name: clusterName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    dnsPrefix: 'bicep'
+  }
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moabukar/miniblue/internal/services/cosmosdb"
 	"github.com/moabukar/miniblue/internal/services/dbmysql"
 	"github.com/moabukar/miniblue/internal/services/dbpostgres"
+	"github.com/moabukar/miniblue/internal/services/deployments"
 	"github.com/moabukar/miniblue/internal/services/dns"
 	"github.com/moabukar/miniblue/internal/services/eventgrid"
 	"github.com/moabukar/miniblue/internal/services/identity"
@@ -196,6 +197,9 @@ func (s *Server) setupRoutes() {
 		{"nsg", func() { nsg.NewHandler(s.store).Register(s.router) }},
 		{"loadbalancer", func() { loadbalancer.NewHandler(s.store).Register(s.router) }},
 		{"appgw", func() { appgw.NewHandler(s.store).Register(s.router) }},
+		{"deployments", func() {
+			deployments.NewHandler(s.store, deployments.NewRouterDispatcher(s.router)).Register(s.router)
+		}},
 	}
 	// Always include core infrastructure in service list
 	s.services = []string{"subscriptions", "tenants"}

--- a/internal/services/deployments/handler.go
+++ b/internal/services/deployments/handler.go
@@ -1,0 +1,222 @@
+// Package deployments emulates Microsoft.Resources/deployments so Bicep
+// (`az deployment group create`) and ARM template applies work end to end.
+//
+// Phase 1 scope: PUT/GET/DELETE/List a deployment, walk template.resources in
+// order, resolve [parameters('x')] and [variables('x')] references, then PUT
+// each resource against the embedded chi router. No copy loops, no
+// conditions, no template expression functions beyond parameters/variables,
+// no nested templates, no outputs evaluation.
+package deployments
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/azerr"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+// Dispatcher serves an internal API call (used to apply each templated
+// resource). The server provides one wrapping its own chi router.
+type Dispatcher func(method, path string, body []byte) (status int, respBody []byte)
+
+type Handler struct {
+	store      *store.Store
+	dispatch   Dispatcher
+	apiVersion string
+}
+
+func NewHandler(s *store.Store, d Dispatcher) *Handler {
+	return &Handler{store: s, dispatch: d, apiVersion: "2021-04-01"}
+}
+
+func (h *Handler) Register(r chi.Router) {
+	r.Route("/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments", func(r chi.Router) {
+		r.Get("/", h.List)
+		r.Route("/{deploymentName}", func(r chi.Router) {
+			r.Put("/", h.CreateOrUpdate)
+			r.Get("/", h.Get)
+			r.Delete("/", h.Delete)
+		})
+	})
+	// Case-insensitive duplicate per Azure ARM convention.
+	r.Get("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deployments", h.List)
+	r.Put("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}", h.CreateOrUpdate)
+	r.Get("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}", h.Get)
+	r.Delete("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}", h.Delete)
+}
+
+func key(sub, rg, name string) string {
+	return "deployment:" + sub + ":" + rg + ":" + name
+}
+
+func (h *Handler) CreateOrUpdate(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "deploymentName")
+
+	var input map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		azerr.BadRequest(w, "could not parse request body")
+		return
+	}
+
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		azerr.BadRequest(w, "properties is required")
+		return
+	}
+	template, _ := props["template"].(map[string]interface{})
+	if template == nil {
+		azerr.BadRequest(w, "properties.template is required")
+		return
+	}
+
+	paramValues := flattenParameters(props["parameters"])
+	vars, _ := template["variables"].(map[string]interface{})
+	tplParams, _ := template["parameters"].(map[string]interface{})
+	mergedParams := mergeParameterDefaults(tplParams, paramValues)
+
+	resources, _ := template["resources"].([]interface{})
+	outputResources := make([]map[string]interface{}, 0, len(resources))
+	state := "Succeeded"
+	var failureMsg string
+
+	for i, raw := range resources {
+		res, _ := raw.(map[string]interface{})
+		if res == nil {
+			continue
+		}
+		evaluated := resolveExpressions(res, mergedParams, vars).(map[string]interface{})
+
+		path, body, err := buildResourceRequest(sub, rg, evaluated)
+		if err != nil {
+			state = "Failed"
+			failureMsg = fmt.Sprintf("resource[%d]: %v", i, err)
+			break
+		}
+		status, respBody := h.dispatch("PUT", path, body)
+		if status >= 300 {
+			state = "Failed"
+			failureMsg = fmt.Sprintf("resource[%d] %s: %d %s", i, path, status, strings.TrimSpace(string(respBody)))
+			break
+		}
+		outputResources = append(outputResources, map[string]interface{}{
+			"id": "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/" + evaluated["type"].(string) + "/" + evaluated["name"].(string),
+		})
+	}
+
+	resp := map[string]interface{}{
+		"id":   "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Resources/deployments/" + name,
+		"name": name,
+		"type": "Microsoft.Resources/deployments",
+		"properties": map[string]interface{}{
+			"provisioningState": state,
+			"mode":              valueOrDefault(props["mode"], "Incremental"),
+			"timestamp":         time.Now().UTC().Format(time.RFC3339),
+			"outputResources":   outputResources,
+			"outputs":           map[string]interface{}{},
+			"parameters":        paramValues,
+		},
+	}
+	if state == "Failed" {
+		resp["properties"].(map[string]interface{})["error"] = map[string]interface{}{
+			"code":    "DeploymentFailed",
+			"message": failureMsg,
+		}
+	}
+
+	_, exists := h.store.Get(key(sub, rg, name))
+	h.store.Set(key(sub, rg, name), resp)
+
+	if exists {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "deploymentName")
+	v, ok := h.store.Get(key(sub, rg, name))
+	if !ok {
+		azerr.NotFound(w, "Microsoft.Resources/deployments", name)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	name := chi.URLParam(r, "deploymentName")
+	if !h.store.Delete(key(sub, rg, name)) {
+		azerr.NotFound(w, "Microsoft.Resources/deployments", name)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	sub := chi.URLParam(r, "subscriptionId")
+	rg := chi.URLParam(r, "resourceGroupName")
+	items := h.store.ListByPrefix("deployment:" + sub + ":" + rg + ":")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"value": items})
+}
+
+// buildResourceRequest converts a (already-evaluated) ARM resource object
+// into the PUT path and JSON body to apply it against the internal router.
+// Nested type segments (e.g. Microsoft.Storage/storageAccounts/blobServices)
+// are split into provider plus instance segments alternating type/name.
+func buildResourceRequest(sub, rg string, res map[string]interface{}) (string, []byte, error) {
+	rType, _ := res["type"].(string)
+	name, _ := res["name"].(string)
+	if rType == "" || name == "" {
+		return "", nil, fmt.Errorf("resource missing type or name")
+	}
+	apiVersion, _ := res["apiVersion"].(string)
+	if apiVersion == "" {
+		apiVersion = "2023-01-01"
+	}
+
+	parts := strings.SplitN(rType, "/", 2)
+	if len(parts) != 2 {
+		return "", nil, fmt.Errorf("invalid type %q (want Provider/resourceType[/sub/...])", rType)
+	}
+	path := "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/" + parts[0] + "/" + parts[1] + "/" + name + "?api-version=" + apiVersion
+
+	body, err := json.Marshal(res)
+	if err != nil {
+		return "", nil, err
+	}
+	return path, body, nil
+}
+
+func valueOrDefault(v interface{}, def string) string {
+	if s, ok := v.(string); ok && s != "" {
+		return s
+	}
+	return def
+}
+
+// NewRouterDispatcher wraps a chi.Router as a Dispatcher by spinning a
+// httptest.ResponseRecorder per call. Lets the deployments handler dispatch
+// templated resources back into the same server without going over TCP.
+func NewRouterDispatcher(router http.Handler) Dispatcher {
+	return func(method, path string, body []byte) (int, []byte) {
+		req := httptest.NewRequest(method, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec.Code, rec.Body.Bytes()
+	}
+}

--- a/internal/services/deployments/handler_test.go
+++ b/internal/services/deployments/handler_test.go
@@ -1,0 +1,193 @@
+package deployments
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moabukar/miniblue/internal/store"
+)
+
+// fakeDispatcher records every call and returns 201.
+type call struct{ method, path string }
+
+func newFakeDispatcher() (Dispatcher, *[]call) {
+	calls := &[]call{}
+	d := func(method, path string, body []byte) (int, []byte) {
+		*calls = append(*calls, call{method: method, path: path})
+		return 201, []byte(`{"name":"ok"}`)
+	}
+	return d, calls
+}
+
+func do(t *testing.T, h http.Handler, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestSimpleDeploymentDispatchesEachResource(t *testing.T) {
+	dispatch, calls := newFakeDispatcher()
+	r := chi.NewRouter()
+	NewHandler(store.New(), dispatch).Register(r)
+
+	body := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"mode": "Incremental",
+			"template": map[string]interface{}{
+				"resources": []interface{}{
+					map[string]interface{}{
+						"type":       "Microsoft.Storage/storageAccounts",
+						"apiVersion": "2023-01-01",
+						"name":       "sa1",
+						"location":   "eastus",
+					},
+					map[string]interface{}{
+						"type":       "Microsoft.KeyVault/vaults",
+						"apiVersion": "2023-07-01",
+						"name":       "kv1",
+						"location":   "eastus",
+					},
+				},
+			},
+		},
+	}
+	resp := do(t, r, "PUT",
+		"/subscriptions/sub1/resourcegroups/rg1/providers/Microsoft.Resources/deployments/d1",
+		body)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("PUT: %d %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]interface{}
+	json.Unmarshal(resp.Body.Bytes(), &out)
+	if state := out["properties"].(map[string]interface{})["provisioningState"]; state != "Succeeded" {
+		t.Errorf("provisioningState: got %v", state)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("dispatcher called %d times, want 2", len(*calls))
+	}
+	if (*calls)[0].path != "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2023-01-01" {
+		t.Errorf("first dispatch path wrong: %s", (*calls)[0].path)
+	}
+}
+
+func TestParameterAndVariableSubstitution(t *testing.T) {
+	dispatch, calls := newFakeDispatcher()
+	r := chi.NewRouter()
+	NewHandler(store.New(), dispatch).Register(r)
+
+	body := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"template": map[string]interface{}{
+				"parameters": map[string]interface{}{
+					"location":    map[string]interface{}{"type": "string", "defaultValue": "westus"},
+					"storageName": map[string]interface{}{"type": "string"},
+				},
+				"variables": map[string]interface{}{
+					"sku": "Standard_LRS",
+				},
+				"resources": []interface{}{
+					map[string]interface{}{
+						"type":       "Microsoft.Storage/storageAccounts",
+						"apiVersion": "2023-01-01",
+						"name":       "[parameters('storageName')]",
+						"location":   "[parameters('location')]",
+						"sku":        map[string]interface{}{"name": "[variables('sku')]"},
+					},
+				},
+			},
+			"parameters": map[string]interface{}{
+				"storageName": map[string]interface{}{"value": "actualname"},
+			},
+		},
+	}
+	if r := do(t, r, "PUT",
+		"/subscriptions/s/resourcegroups/r/providers/Microsoft.Resources/deployments/d",
+		body); r.Code != http.StatusCreated {
+		t.Fatalf("%d %s", r.Code, r.Body.String())
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("calls: %+v", *calls)
+	}
+	want := "/subscriptions/s/resourceGroups/r/providers/Microsoft.Storage/storageAccounts/actualname?api-version=2023-01-01"
+	if (*calls)[0].path != want {
+		t.Errorf("path: got %s", (*calls)[0].path)
+	}
+}
+
+func TestDispatcherFailureMarksDeploymentFailed(t *testing.T) {
+	r := chi.NewRouter()
+	failing := func(method, path string, body []byte) (int, []byte) {
+		return 500, []byte(`{"error":"boom"}`)
+	}
+	NewHandler(store.New(), failing).Register(r)
+
+	body := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"template": map[string]interface{}{
+				"resources": []interface{}{
+					map[string]interface{}{
+						"type":       "Microsoft.Storage/storageAccounts",
+						"apiVersion": "2023-01-01",
+						"name":       "sa",
+					},
+				},
+			},
+		},
+	}
+	resp := do(t, r, "PUT",
+		"/subscriptions/s/resourcegroups/r/providers/Microsoft.Resources/deployments/d",
+		body)
+	// Deployment record itself is 201; provisioningState reflects the failure.
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("%d %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]interface{}
+	json.Unmarshal(resp.Body.Bytes(), &out)
+	props := out["properties"].(map[string]interface{})
+	if props["provisioningState"] != "Failed" {
+		t.Errorf("state: %v", props["provisioningState"])
+	}
+	if _, ok := props["error"]; !ok {
+		t.Errorf("expected error field, got %+v", props)
+	}
+}
+
+func TestGetDelete(t *testing.T) {
+	dispatch, _ := newFakeDispatcher()
+	r := chi.NewRouter()
+	NewHandler(store.New(), dispatch).Register(r)
+
+	body := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"template": map[string]interface{}{
+				"resources": []interface{}{},
+			},
+		},
+	}
+	do(t, r, "PUT",
+		"/subscriptions/s/resourcegroups/r/providers/Microsoft.Resources/deployments/d",
+		body)
+	if rr := do(t, r, "GET",
+		"/subscriptions/s/resourcegroups/r/providers/Microsoft.Resources/deployments/d", nil); rr.Code != http.StatusOK {
+		t.Errorf("GET: %d", rr.Code)
+	}
+	if rr := do(t, r, "DELETE",
+		"/subscriptions/s/resourcegroups/r/providers/Microsoft.Resources/deployments/d", nil); rr.Code != http.StatusNoContent {
+		t.Errorf("DELETE: %d", rr.Code)
+	}
+	if rr := do(t, r, "GET",
+		"/subscriptions/s/resourcegroups/r/providers/Microsoft.Resources/deployments/d", nil); rr.Code != http.StatusNotFound {
+		t.Errorf("GET after delete: %d", rr.Code)
+	}
+}

--- a/internal/services/deployments/template.go
+++ b/internal/services/deployments/template.go
@@ -1,0 +1,99 @@
+package deployments
+
+import (
+	"regexp"
+	"strings"
+)
+
+// flattenParameters takes the deployment's "parameters" object (which has
+// shape {"name": {"value": ...}}) and returns {"name": value}.
+func flattenParameters(raw interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	m, _ := raw.(map[string]interface{})
+	for k, v := range m {
+		entry, _ := v.(map[string]interface{})
+		if entry == nil {
+			continue
+		}
+		if val, ok := entry["value"]; ok {
+			out[k] = val
+		}
+	}
+	return out
+}
+
+// mergeParameterDefaults merges template.parameters defaultValue settings
+// with the deployment's explicit parameter values. Explicit wins.
+func mergeParameterDefaults(tplParams map[string]interface{}, supplied map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	for k, v := range tplParams {
+		entry, _ := v.(map[string]interface{})
+		if entry == nil {
+			continue
+		}
+		if def, ok := entry["defaultValue"]; ok {
+			out[k] = def
+		}
+	}
+	for k, v := range supplied {
+		out[k] = v
+	}
+	return out
+}
+
+// resolveExpressions walks a parsed JSON value and substitutes ARM template
+// expressions of the form "[parameters('x')]" and "[variables('x')]" with
+// their concrete values. Other expression functions (concat, resourceId,
+// reference, copyIndex, etc.) are passed through unchanged in Phase 1; the
+// template author should pre-resolve them or use literals.
+func resolveExpressions(v interface{}, params, vars map[string]interface{}) interface{} {
+	switch t := v.(type) {
+	case string:
+		return resolveString(t, params, vars)
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, vv := range t {
+			out[k] = resolveExpressions(vv, params, vars)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, item := range t {
+			out[i] = resolveExpressions(item, params, vars)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+var (
+	// Whole-string parameter/variable references. Evaluated to the underlying
+	// value (which may itself be any JSON type).
+	wholeParam = regexp.MustCompile(`^\[parameters\('([^']+)'\)\]$`)
+	wholeVar   = regexp.MustCompile(`^\[variables\('([^']+)'\)\]$`)
+	// Embedded references inside a larger string (rare in well-formed templates
+	// but Bicep can emit them via `${}` interpolation that lowers to concat).
+	// We do NOT try to handle concat() here; we only inline whole-string forms.
+)
+
+func resolveString(s string, params, vars map[string]interface{}) interface{} {
+	if m := wholeParam.FindStringSubmatch(s); m != nil {
+		if v, ok := params[m[1]]; ok {
+			return v
+		}
+		return s
+	}
+	if m := wholeVar.FindStringSubmatch(s); m != nil {
+		if v, ok := vars[m[1]]; ok {
+			return v
+		}
+		return s
+	}
+	// Pass through any other [...] expressions unchanged. A WARNING-style
+	// trace could be added here if we wanted to flag unsupported functions.
+	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+		return s
+	}
+	return s
+}


### PR DESCRIPTION
Closes part of #66 and #74. Lets `az deployment group create --template-file main.bicep` work end to end against miniblue.

## Phase 1 supports
- PUT/GET/DELETE/List on `Microsoft.Resources/deployments`
- Linear iteration of `template.resources` in declaration order
- `[parameters('name')]` and `[variables('name')]` substitution
- Each resource dispatched via the embedded chi router into existing handlers
- Per-resource error surfaced as Failed deployment

## Deferred (will track in a follow-up issue)
Template functions beyond parameters/variables, copy loops, conditions, nested templates, `dependsOn` ordering, outputs evaluation, non-RG-scope deployments, what-if/validate.

## Tests
4 unit tests, full suite green, locally smoke-tested against `storage account` + `aks` resources.