### PR TITLE
fix(compose): use bundled /healthcheck binary instead of wget

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - PORT=4566
       - LOG_LEVEL=info
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4566/health"]
+      test: ["CMD", "/healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Problem
`docker-compose.yml` defines a healthcheck that runs `wget`, but the
`slim` target in the Dockerfile is built `FROM scratch` and does not
include `wget` (or any shell). The probe therefore never resolves and
the container is permanently reported as `unhealthy`, even though
`/health` returns 200.

## Fix
Use the `/healthcheck` Go binary that is already built and copied into
the image (see `cmd/healthcheck/main.go` and the `HEALTHCHECK` line in
the Dockerfile). One-line change to `docker-compose.yml`.

## Verification
Rebuilt the image and brought up the stack:

| | Before (`wget`) | After (`/healthcheck`) |
|---|---|---|
| `Health.Status` | `unhealthy` | `healthy` |
| `ExitCode` | non-zero (binary missing) | `0` |
| `FailingStreak` | growing | `0` |
| `/health` from host | n/a | HTTP 200 |