### PR TITLE
feat(examples): add Java example for Resource Groups, Key Vault, Blob, Cosmos DB

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Code examples showing how to use miniblue with different languages and tools.
 | [go/](go/) | Go | HTTP client for resource groups and Key Vault |
 | [javascript/](javascript/) | JavaScript | Fetch API for resource groups, Key Vault, Blob Storage |
 | [dotnet/](dotnet/) | C# / .NET 10 | Resource groups, Key Vault, Blob Storage, Cosmos DB |
+| [java/](java/) | Java 17+ | HttpClient for resource groups, Key Vault, Blob Storage, Cosmos DB |
 | [terraform/](terraform/) | HCL | Terraform azurerm provider with networking, storage, DNS and more |
 | [ci/](ci/) | YAML | GitHub Actions workflow with miniblue as a service container |
 
@@ -25,4 +26,5 @@ Then run any example:
     cd examples/go && go run main.go
     cd examples/javascript && node example.js
     cd examples/dotnet && dotnet run
+    cd examples/java && mvn -q compile exec:java
     cd examples/terraform && export SSL_CERT_FILE=~/.miniblue/cert.pem && terraform init && terraform apply

--- a/examples/java/.gitignore
+++ b/examples/java/.gitignore
@@ -1,0 +1,3 @@
+target/
+.mvn/
+*.class

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,0 +1,63 @@
+# miniblue Java Example
+
+Demonstrates four Azure services running against **[miniblue](https://github.com/moabukar/miniblue)** - a free, open-source local Azure emulator.
+
+All calls go to `http://localhost:4566` using the built-in `java.net.http.HttpClient`. No real Azure subscription or credentials required.
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| [JDK](https://adoptium.net/) | 17+ |
+| [Maven](https://maven.apache.org/) | 3.8+ |
+| [Docker](https://docs.docker.com/get-docker/) | any recent |
+
+## Start miniblue
+
+```bash
+docker run -p 4566:4566 -p 4567:4567 moabukar/miniblue:latest
+```
+
+## Run the example
+
+```bash
+cd examples/java
+mvn -q compile exec:java
+```
+
+Expected output:
+
+```
+miniblue Java example
+=========================
+
+Resource Group: java-rg (eastus)
+All resource groups:
+  - java-rg
+
+Secret stored: db-password
+Secret value:  super-secret-java-123
+
+Container created: data
+Blob uploaded: config.json
+Blob content:  {"database":"postgres://localhost:5432/mydb","env":"local"}
+
+Cosmos doc created: user1
+Cosmos doc: Mo (admin)
+
+All calls went to miniblue!
+```
+
+## What each file does
+
+| File | Service | Operations |
+|------|---------|------------|
+| `ResourceGroupExample.java` | ARM Resource Groups | Create, list |
+| `KeyVaultExample.java` | Key Vault Secrets | Set, get |
+| `BlobStorageExample.java` | Blob Storage | Create container, upload, download |
+| `CosmosDbExample.java` | Cosmos DB | Insert document, read document |
+
+## Notes
+
+- The Azure SDK clients for Key Vault (`azure-security-keyvault-secrets`) and Blob Storage (`azure-storage-blob`) enforce HTTPS or use incompatible path-style URL parsing for custom endpoints, so this example uses `HttpClient` directly - mirroring the approach in the .NET and Python examples.
+- miniblue does **not** validate authentication tokens or HMAC signatures.

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.miniblue</groupId>
+    <artifactId>example</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.18.2</jackson.version>
+        <exec.plugin.version>3.5.0</exec.plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.plugin.version}</version>
+                <configuration>
+                    <mainClass>com.miniblue.example.Main</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/src/main/java/com/miniblue/example/BlobStorageExample.java
+++ b/examples/java/src/main/java/com/miniblue/example/BlobStorageExample.java
@@ -1,0 +1,44 @@
+package com.miniblue.example;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+
+// Blob Storage (HttpClient)
+// The Azure Blob Storage SDK interprets path-style URIs as
+// http://{host}/{accountName}/... - "blob" would be parsed as the account name
+// when the service URI is http://localhost:4566/blob/javaaccount, which generates
+// wrong blob URLs. miniblue's blob API uses simple path-based routing, so
+// HttpClient is used directly here.
+final class BlobStorageExample {
+    private static final String BASE_URL = "http://localhost:4566";
+
+    private final HttpClient http = HttpClient.newHttpClient();
+
+    void run() throws Exception {
+        HttpRequest createContainer = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/blob/javaaccount/data"))
+                .PUT(BodyPublishers.noBody())
+                .build();
+        http.send(createContainer, BodyHandlers.discarding());
+        System.out.println("\nContainer created: data");
+
+        String payload = "{\"database\":\"postgres://localhost:5432/mydb\",\"env\":\"local\"}";
+        HttpRequest uploadBlob = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/blob/javaaccount/data/config.json"))
+                .header("Content-Type", "application/json")
+                .PUT(BodyPublishers.ofString(payload))
+                .build();
+        http.send(uploadBlob, BodyHandlers.discarding());
+        System.out.println("Blob uploaded: config.json");
+
+        HttpRequest getBlob = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/blob/javaaccount/data/config.json"))
+                .GET()
+                .build();
+        String body = http.send(getBlob, BodyHandlers.ofString()).body();
+        System.out.println("Blob content:  " + body);
+    }
+}

--- a/examples/java/src/main/java/com/miniblue/example/CosmosDbExample.java
+++ b/examples/java/src/main/java/com/miniblue/example/CosmosDbExample.java
@@ -1,0 +1,46 @@
+package com.miniblue.example;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// Cosmos DB (HttpClient)
+// The Azure Cosmos SDK requires a Cosmos-compatible discovery endpoint, which
+// miniblue does not expose. miniblue's Cosmos API uses simple path-based
+// routing, so HttpClient is used directly here.
+final class CosmosDbExample {
+    private static final String BASE_URL = "http://localhost:4566";
+
+    private final HttpClient http = HttpClient.newHttpClient();
+    private final ObjectMapper json = new ObjectMapper();
+
+    void run() throws Exception {
+        String body = json.writeValueAsString(Map.of(
+                "id", "user1",
+                "name", "Mo",
+                "role", "admin"
+        ));
+        HttpRequest insert = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/cosmosdb/myaccount/dbs/app/colls/users/docs"))
+                .header("Content-Type", "application/json")
+                .POST(BodyPublishers.ofString(body))
+                .build();
+        http.send(insert, BodyHandlers.discarding());
+        System.out.println("\nCosmos doc created: user1");
+
+        HttpRequest read = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/cosmosdb/myaccount/dbs/app/colls/users/docs/user1"))
+                .GET()
+                .build();
+        String responseBody = http.send(read, BodyHandlers.ofString()).body();
+        JsonNode doc = json.readTree(responseBody);
+        System.out.printf("Cosmos doc: %s (%s)%n",
+                doc.get("name").asText(), doc.get("role").asText());
+    }
+}

--- a/examples/java/src/main/java/com/miniblue/example/KeyVaultExample.java
+++ b/examples/java/src/main/java/com/miniblue/example/KeyVaultExample.java
@@ -1,0 +1,41 @@
+package com.miniblue.example;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// Key Vault (HttpClient)
+// The Azure Key Vault SDK enforces HTTPS at the transport level and cannot be
+// used with an http:// endpoint. miniblue's Key Vault API uses simple path-based
+// routing, so HttpClient is used directly here.
+final class KeyVaultExample {
+    private static final String BASE_URL = "http://localhost:4566";
+
+    private final HttpClient http = HttpClient.newHttpClient();
+    private final ObjectMapper json = new ObjectMapper();
+
+    void run() throws Exception {
+        String body = json.writeValueAsString(Map.of("value", "super-secret-java-123"));
+        HttpRequest setReq = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/keyvault/myvault/secrets/db-password"))
+                .header("Content-Type", "application/json")
+                .PUT(BodyPublishers.ofString(body))
+                .build();
+        http.send(setReq, BodyHandlers.discarding());
+        System.out.println("\nSecret stored: db-password");
+
+        HttpRequest getReq = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/keyvault/myvault/secrets/db-password"))
+                .GET()
+                .build();
+        String response = http.send(getReq, BodyHandlers.ofString()).body();
+        JsonNode secret = json.readTree(response);
+        System.out.println("Secret value:  " + secret.get("value").asText());
+    }
+}

--- a/examples/java/src/main/java/com/miniblue/example/Main.java
+++ b/examples/java/src/main/java/com/miniblue/example/Main.java
@@ -1,0 +1,24 @@
+package com.miniblue.example;
+
+/*
+ * miniblue Java example
+ *
+ * Start miniblue: docker run -p 4566:4566 moabukar/miniblue:latest
+ * Run:            mvn -q compile exec:java
+ *
+ * Demonstrates Resource Groups, Key Vault, Blob Storage, and Cosmos DB
+ * using java.net.http.HttpClient pointed at http://localhost:4566.
+ */
+public final class Main {
+    public static void main(String[] args) throws Exception {
+        System.out.println("miniblue Java example");
+        System.out.println("=========================\n");
+
+        new ResourceGroupExample().run();
+        new KeyVaultExample().run();
+        new BlobStorageExample().run();
+        new CosmosDbExample().run();
+
+        System.out.println("\nAll calls went to miniblue!");
+    }
+}

--- a/examples/java/src/main/java/com/miniblue/example/ResourceGroupExample.java
+++ b/examples/java/src/main/java/com/miniblue/example/ResourceGroupExample.java
@@ -1,0 +1,51 @@
+package com.miniblue.example;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// Resource Groups (HttpClient)
+// The Azure ResourceManager SDK requires HTTPS for Bearer token auth and
+// performs ARM service discovery that miniblue does not fully support. miniblue's
+// resource group API uses simple path-based routing, so HttpClient is used
+// directly here.
+final class ResourceGroupExample {
+    private static final String BASE_URL = "http://localhost:4566";
+    private static final String SUB_ID = "00000000-0000-0000-0000-000000000000";
+
+    private final HttpClient http = HttpClient.newHttpClient();
+    private final ObjectMapper json = new ObjectMapper();
+
+    void run() throws Exception {
+        String body = json.writeValueAsString(Map.of(
+                "location", "eastus",
+                "tags", Map.of("env", "local", "sdk", "java")
+        ));
+        HttpRequest createReq = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/subscriptions/" + SUB_ID + "/resourcegroups/java-rg"))
+                .header("Content-Type", "application/json")
+                .PUT(BodyPublishers.ofString(body))
+                .build();
+        String createBody = http.send(createReq, BodyHandlers.ofString()).body();
+        JsonNode rg = json.readTree(createBody);
+        System.out.printf("Resource Group: %s (%s)%n",
+                rg.get("name").asText(), rg.get("location").asText());
+
+        HttpRequest listReq = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + "/subscriptions/" + SUB_ID + "/resourcegroups"))
+                .GET()
+                .build();
+        String listBody = http.send(listReq, BodyHandlers.ofString()).body();
+        JsonNode list = json.readTree(listBody);
+        System.out.println("All resource groups:");
+        for (JsonNode item : list.get("value")) {
+            System.out.println("  - " + item.get("name").asText());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a Java example mirroring the .NET one, covering the same four
services: Resource Groups, Key Vault, Blob Storage, and Cosmos DB.

The example uses the built-in `java.net.http.HttpClient` (Java 17+) and
Jackson for JSON. Same rationale as the .NET, JS and Python examples:
the Azure SDKs for these services either enforce HTTPS or perform
service discovery that is incompatible with miniblue's path-based
routing, so `HttpClient` is used directly.

## Run
```bash
cd examples/java
mvn -q compile exec:java
```

## Verification
Built with `mvn compile` and ran end-to-end against a running miniblue
instance (`docker run -p 4566:4566 moabukar/miniblue:latest`). All four
services return the expected output:

```
miniblue Java example
=========================

Resource Group: java-rg (eastus)
All resource groups:
  - java-rg

Secret stored: db-password
Secret value:  super-secret-java-123

Container created: data
Blob uploaded: config.json
Blob content:  {"database":"postgres://localhost:5432/mydb","env":"local"}

Cosmos doc created: user1
Cosmos doc: Mo (admin)

All calls went to miniblue!
```